### PR TITLE
Add SwiftPM cache to CI workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,6 +58,16 @@ jobs:
         with:
           fetch-depth: 10
 
+      - name: Cache SwiftPM packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/org.swift.swiftpm
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Set Xcode IDE Preferences
         run: |
           sudo defaults write /Library/Preferences/com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES


### PR DESCRIPTION
## Summary
- cache SwiftPM dependencies in GitHub Actions

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684777ee61e483319476538dc483b2bf