### PR TITLE
Add quick action scene routing

### DIFF
--- a/Azkar/Info.plist
+++ b/Azkar/Info.plist
@@ -84,6 +84,18 @@
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).QuickActionSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>

--- a/Azkar/Sources/AppDelegate.swift
+++ b/Azkar/Sources/AppDelegate.swift
@@ -19,12 +19,41 @@ import FirebaseMessaging
 import Mixpanel
 import CoreSpotlight
 
+private let quickActionTypePrefix = "io.jawziyya.azkar-app.quick-action."
+
+@MainActor
+@discardableResult
+private func dispatchQuickActionItem(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
+    let type = shortcutItem.type
+    guard type.hasPrefix(quickActionTypePrefix) else { return false }
+    let categoryRawValue = String(type.dropFirst(quickActionTypePrefix.count))
+    guard let category = ZikrCategory(rawValue: categoryRawValue) else { return false }
+    QuickActionDispatcher.shared.enqueue(.azkar(category))
+    return true
+}
+
 @MainActor
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let player = AudioPlayer()
     let notificationsHandler = NotificationsHandler.shared
     private let spotlightIndexer = SpotlightIndexer.shared
+
+    private func buildShortcutItems() -> [UIApplicationShortcutItem] {
+        ZikrCategory.allCases.map { category in
+            UIApplicationShortcutItem(
+                type: quickActionTypePrefix + category.rawValue,
+                localizedTitle: category.title,
+                localizedSubtitle: nil,
+                icon: UIApplicationShortcutIcon(systemImageName: category.systemImageName)
+            )
+        }
+    }
+
+    @discardableResult
+    fileprivate func handleQuickActionItem(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
+        dispatchQuickActionItem(shortcutItem)
+    }
     
     func application(
         _ application: UIApplication,
@@ -40,6 +69,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         application.beginReceivingRemoteControlEvents()
         application.registerForRemoteNotifications()
+        application.shortcutItems = buildShortcutItems()
         initialize(launchOptions: launchOptions)
         spotlightIndexer.indexIfNeeded()
         if let launchOptions, let userInfo = launchOptions[.remoteNotification] as? [AnyHashable: Any] {
@@ -50,12 +80,33 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(
         _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(
+            name: nil,
+            sessionRole: connectingSceneSession.role
+        )
+        configuration.delegateClass = QuickActionSceneDelegate.self
+        return configuration
+    }
+
+    func application(
+        _ application: UIApplication,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        completionHandler(handleQuickActionItem(shortcutItem))
+    }
+
+    func application(
+        _ application: UIApplication,
         continue userActivity: NSUserActivity,
         restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
     ) -> Bool {
         return false
     }
-    
+
     func application(
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
@@ -181,4 +232,28 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
     
+}
+
+@MainActor
+final class QuickActionSceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let shortcutItem = connectionOptions.shortcutItem else {
+            return
+        }
+        _ = dispatchQuickActionItem(shortcutItem)
+    }
+
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        let wasHandled = dispatchQuickActionItem(shortcutItem)
+        completionHandler(wasHandled)
+    }
 }

--- a/Azkar/Sources/AzkarApp.swift
+++ b/Azkar/Sources/AzkarApp.swift
@@ -7,6 +7,7 @@ import Entities
 import AudioPlayer
 import StoreKit
 import CoreSpotlight
+import Combine
 
 @main
 struct AzkarApp: App {
@@ -17,6 +18,7 @@ struct AzkarApp: App {
     
     let preferences = Preferences.shared
     let deepLinker = Deeplinker.shared
+    let quickActionDispatcher = QuickActionDispatcher.shared
     
     init() {
         setNavigationBarFont(theme: preferences.appTheme, colorTheme: preferences.colorTheme)
@@ -60,10 +62,14 @@ struct AzkarApp: App {
                 }
                 self.deepLinker.open(.azkar(category))
             }
+            .onReceive(quickActionDispatcher.routes) { route in
+                deepLinker.open(route)
+            }
             .onOpenURL { url in
                 handleIncomingURL(url)
             }
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                handlePendingQuickAction()
                 handleControlCenterDeepLink()
             }
             .onContinueUserActivity(CSSearchableItemActionType) { userActivity in
@@ -81,6 +87,13 @@ struct AzkarApp: App {
         }
         defaults?.removeObject(forKey: "controlCenterDeepLink")
         handleIncomingURL(url)
+    }
+
+    private func handlePendingQuickAction() {
+        guard let route = quickActionDispatcher.takePendingRoute() else {
+            return
+        }
+        deepLinker.open(route)
     }
 
     private func handleIncomingURL(_ url: URL) {

--- a/Azkar/Sources/Library/QuickActionDispatcher.swift
+++ b/Azkar/Sources/Library/QuickActionDispatcher.swift
@@ -1,0 +1,24 @@
+import Combine
+
+@MainActor
+final class QuickActionDispatcher {
+
+    static let shared = QuickActionDispatcher()
+
+    private let routeSubject = PassthroughSubject<Deeplinker.Route, Never>()
+    private var pendingRoute: Deeplinker.Route?
+
+    var routes: AnyPublisher<Deeplinker.Route, Never> {
+        routeSubject.eraseToAnyPublisher()
+    }
+
+    func enqueue(_ route: Deeplinker.Route) {
+        pendingRoute = route
+        routeSubject.send(route)
+    }
+
+    func takePendingRoute() -> Deeplinker.Route? {
+        defer { pendingRoute = nil }
+        return pendingRoute
+    }
+}

--- a/Azkar/Sources/Navigation/AppNavigator.swift
+++ b/Azkar/Sources/Navigation/AppNavigator.swift
@@ -25,9 +25,7 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
         self.dependencies = dependencies
         self.deeplinker = deeplinker
         observeDeepLinks()
-        if let pendingRoute = deeplinker.takePendingRoute() {
-            handleDeepLink(pendingRoute)
-        }
+        handlePendingDeepLinkIfNeeded()
     }
 
     var selectedPagePublisher: AnyPublisher<Int, Never> {
@@ -123,8 +121,16 @@ private extension AppNavigator {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] route in
                 self?.handleDeepLink(route)
+                _ = self?.deeplinker.takePendingRoute()
             }
             .store(in: &cancellables)
+    }
+
+    func handlePendingDeepLinkIfNeeded() {
+        guard let route = deeplinker.takePendingRoute() else {
+            return
+        }
+        handleDeepLink(route)
     }
 
     func handleDeepLink(_ route: Deeplinker.Route) {


### PR DESCRIPTION
## Summary
- add scene-based routing for Home Screen quick actions
- introduce a dedicated quick-action dispatcher
- forward quick-action routes into the existing deeplink navigation flow

## Notes
- branch head: `cfe6e58`
- not runtime-verified in the simulator from the current environment