### PR TITLE
Ship accessibility and stability fixes from isolated worktrees

### DIFF
--- a/Azkar/Sources/Library/Keys.swift
+++ b/Azkar/Sources/Library/Keys.swift
@@ -58,5 +58,6 @@ enum Keys {
     static let pageIndicatorsMode = "kPageIndicatorsMode"
     static let pageIndicatorsCategories = "kPageIndicatorsCategories"
     static let azkarCounterLastChangeDate = "kAzkarCounterLastChangeDate"
+    static let didDisplayCounterOnboardingTip = "kDidDisplayCounterOnboardingTip"
     
 }

--- a/Azkar/Sources/Scenes/Item Picker/ItemPickerView.swift
+++ b/Azkar/Sources/Scenes/Item Picker/ItemPickerView.swift
@@ -36,7 +36,7 @@ struct ItemPickerView<SelectionValue>: View where SelectionValue: Hashable & Ide
 
     var content: some View {
         ForEachIndexed(items) { _, position, item in
-            let isSelected = selection.hashValue == item.hashValue
+            let isSelected = selection == item
             let isProtected = isItemProtected(item) && !isSelected
             Button {
                 DispatchQueue.main.async {

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
@@ -110,6 +110,7 @@ struct MainMenuView: View {
                 Button(action: viewModel.navigateToSettings) {
                     Image(systemName: "gear")
                 }
+                .accessibilityLabel(Text("settings.title"))
             }
         }
         .background(

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
@@ -135,14 +135,6 @@ final class MainMenuViewModel: ObservableObject {
             ),
         ]
 
-        do {
-            if let fadl = try databaseService.getRandomFadl() {
-                print(fadl)
-            }
-        } catch {
-            print(error)
-        }
-
         var year = "\(Date().hijriYear) г.х."
         switch Calendar.current.identifier {
         case .islamic, .islamicCivil, .islamicTabular, .islamicUmmAlQura:

--- a/Azkar/Sources/Scenes/Settings/Reminders/Sound Picker/ReminderSoundPickerView.swift
+++ b/Azkar/Sources/Scenes/Settings/Reminders/Sound Picker/ReminderSoundPickerView.swift
@@ -15,12 +15,6 @@ struct ReminderSoundPickerView: View {
                     VStack {
                         ForEachIndexed(section.sounds) { _, position, sound in
                             soundView(sound)
-                                .onTapGesture {
-                                    DispatchQueue.main.async {
-                                        viewModel.playSound(sound)
-                                        viewModel.setPreferredSound(sound)
-                                    }
-                                }
                             if position != .last {
                                 Divider()
                             }
@@ -40,22 +34,46 @@ struct ReminderSoundPickerView: View {
     }
     
     private func soundView(_ sound: ReminderSound) -> some View {
-        HStack(alignment: .center, spacing: 8) {
-            Text(sound.title)
-                .multilineTextAlignment(.leading)
-                .systemFont(.body)
-            
-            Spacer()
+        let isSelected = viewModel.preferredSound == sound
+        let hasAccess = viewModel.hasAccessToSound(sound)
 
-            if viewModel.hasAccessToSound(sound) || viewModel.preferredSound == sound {
-                CheckboxView(isCheked: .constant(viewModel.preferredSound == sound))
-                    .frame(width: 20, height: 20)
-            } else {
-                ProBadgeView()
+        return Button {
+            DispatchQueue.main.async {
+                viewModel.playSound(sound)
+                viewModel.setPreferredSound(sound)
             }
+        } label: {
+            HStack(alignment: .center, spacing: 8) {
+                Text(sound.title)
+                    .multilineTextAlignment(.leading)
+                    .systemFont(.body)
+                
+                Spacer()
+
+                if hasAccess || isSelected {
+                    CheckboxView(isCheked: .constant(isSelected))
+                        .frame(width: 20, height: 20)
+                } else {
+                    ProBadgeView()
+                }
+            }
+            .contentShape(Rectangle())
+            .frame(minHeight: 44)
         }
-        .contentShape(Rectangle())
-        .frame(minHeight: 44)
+        .buttonStyle(.plain)
+        .foregroundStyle(.text)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(sound.title)
+        .accessibilityValue(soundAccessibilityValue(isSelected: isSelected, hasAccess: hasAccess))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func soundAccessibilityValue(isSelected: Bool, hasAccess: Bool) -> Text {
+        if !hasAccess && !isSelected {
+            return Text("accessibility.item-picker.locked")
+        }
+
+        return isSelected ? Text("accessibility.common.selected") : Text("accessibility.common.not-selected")
     }
     
 }

--- a/Azkar/Sources/Scenes/Settings/Reminders/Sound Picker/ReminderSoundPickerView.swift
+++ b/Azkar/Sources/Scenes/Settings/Reminders/Sound Picker/ReminderSoundPickerView.swift
@@ -47,7 +47,7 @@ struct ReminderSoundPickerView: View {
                 Text(sound.title)
                     .multilineTextAlignment(.leading)
                     .systemFont(.body)
-                
+
                 Spacer()
 
                 if hasAccess || isSelected {

--- a/Azkar/Sources/Scenes/Settings/SettingsView.swift
+++ b/Azkar/Sources/Scenes/Settings/SettingsView.swift
@@ -41,6 +41,7 @@ struct SettingsView: View {
                 Button(action: viewModel.navigateToAboutAppScreen) {
                     Image(systemName: "info.circle")
                 }
+                .accessibilityLabel(Text("about.title"))
             }
         }
         .customScrollContentBackground()

--- a/Azkar/Sources/Scenes/Zikr Pages/ZikrPagesView.swift
+++ b/Azkar/Sources/Scenes/Zikr Pages/ZikrPagesView.swift
@@ -40,8 +40,7 @@ struct ZikrPagesView: View, Equatable {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigation) {
-                let page = viewModel.pages[viewModel.page]
-                if page != .readingCompletion {
+                if let page = viewModel.pages[safe: viewModel.page], page != .readingCompletion {
                     HStack {
                         Button(systemImage: .squareAndArrowUp, action: viewModel.shareCurrentZikr)
                             .accessibilityLabel(Text("common.share"))

--- a/Azkar/Sources/Scenes/Zikr View/ZikrView.swift
+++ b/Azkar/Sources/Scenes/Zikr View/ZikrView.swift
@@ -17,7 +17,7 @@ import Entities
  */
 struct ZikrView: View {
     
-    @AppStorage("kDidDisplayCounterOnboardingTip", store: UserDefaults.standard)
+    @AppStorage(Keys.didDisplayCounterOnboardingTip, store: UserDefaults.standard)
     var didDisplayCounterOnboardingTip: Bool?
 
     @ObservedObject var viewModel: ZikrViewModel

--- a/Packages/Core/Sources/Extensions/ContentSizeCategory.swift
+++ b/Packages/Core/Sources/Extensions/ContentSizeCategory.swift
@@ -50,8 +50,14 @@ extension ContentSizeCategory: Codable {
     }
 
     public init(floatValue: CGFloat) {
+        guard floatValue.isFinite else {
+            self = .medium
+            return
+        }
+
         let index = Int(round(floatValue / ContentSizeCategory.stride))
-        self = ContentSizeCategory.allCases[index]
+        let clampedIndex = min(max(index, 0), ContentSizeCategory.allCases.count - 1)
+        self = ContentSizeCategory.allCases[clampedIndex]
     }
 
     public var name: String {

--- a/Packages/Modules/Sources/ArticleReader/ArticleStatsView.swift
+++ b/Packages/Modules/Sources/ArticleReader/ArticleStatsView.swift
@@ -20,24 +20,32 @@ struct ArticleStatsView: View {
     let abbreviatedNumber: String
     let number: Int
     let imageName: String
-    @State var showNumber = false
+    @State private var showNumber = false
+
+    private var canShowPopover: Bool {
+        number.description != abbreviatedNumber
+    }
+
+    private func togglePopover() {
+        guard canShowPopover else { return }
+        withAnimation(.spring) {
+            showNumber.toggle()
+        }
+    }
     
     var body: some View {
-        HStack {
-            Image(systemName: imageName)
-//                .resizable()
-//                .aspectRatio(contentMode: .fit)
-//                .frame(width: 15, height: 15)
-            Text(abbreviatedNumber)
-                .applyNumericTransition(Double(number))
-        }
-        .font(Font.caption)
-        .onTapGesture {
-            guard number.description != abbreviatedNumber else { return }
-            withAnimation(.spring) {
-                showNumber.toggle()
+        Button(action: togglePopover) {
+            HStack {
+                Image(systemName: imageName)
+                    .accessibilityHidden(true)
+                Text(abbreviatedNumber)
+                    .applyNumericTransition(Double(number))
             }
         }
+        .buttonStyle(.plain)
+        .font(Font.caption)
+        .accessibilityValue(Text(number.description))
+        .disabled(canShowPopover == false)
         .popover(
             present: $showNumber,
             view: {

--- a/Packages/Modules/Sources/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/Packages/Modules/Sources/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -101,8 +101,9 @@ extension AudioPlayer {
 
         case .routeChanged:
             //In some route changes, the player pause automatically
-            //TODO: there should be a check if state == playing
-            if let currentItemTimebase = player?.currentItem?.timebase, CMTimebaseGetRate(currentItemTimebase) == 0 {
+            if state.isPlaying,
+                let currentItemTimebase = player?.currentItem?.timebase,
+                CMTimebaseGetRate(currentItemTimebase) == 0 {
                 state = .paused
             }
 

--- a/Packages/Modules/Sources/Library/Views/AdBottomSheetView.swift
+++ b/Packages/Modules/Sources/Library/Views/AdBottomSheetView.swift
@@ -55,6 +55,7 @@ public struct AdBottomSheetView: View {
                             .shadow(radius: 4)
                             .padding()
                     }
+                    .accessibilityLabel(Text("common.cancel"))
                 }
                 
                 VStack(alignment: .leading, spacing: 16) {

--- a/Packages/Modules/Sources/Library/Views/AdButton.swift
+++ b/Packages/Modules/Sources/Library/Views/AdButton.swift
@@ -48,6 +48,9 @@ public struct AdButton: View {
                 .glassEffectCompat(.regular.interactive(true), in: RoundedRectangle(cornerRadius: cornerRadius))
         }
         .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .accessibilityAction(named: Text("common.cancel")) {
+            onClose()
+        }
     }
 
     var label: some View {
@@ -131,6 +134,7 @@ public struct AdButton: View {
             .foregroundStyle(effectiveforegroundStyle)
             .padding(presentationType.scale * 5)
             .contentShape(Rectangle())
+            .accessibilityHidden(true)
             .highPriorityGesture(
                 TapGesture()
                     .onEnded(onClose)

--- a/Packages/Modules/Sources/ZikrCollectionsOnboarding/ZikrCollectionsOnboardingScreen.swift
+++ b/Packages/Modules/Sources/ZikrCollectionsOnboarding/ZikrCollectionsOnboardingScreen.swift
@@ -24,6 +24,7 @@ struct ZikrCollectionsOnboardingScreen: View {
                 }
                 .opacity(0.5)
                 .buttonStyle(.plain)
+                .accessibilityLabel(Text("common.cancel"))
                 .padding()                
             }
         }


### PR DESCRIPTION
## Summary
- ship eleven completed Paperclip worktree fixes covering accessibility, stability, and small UX correctness improvements
- improve accessibility for reminder sound selection, ad dismissal, article stats, toolbar buttons, and onboarding dismissal
- fix a potential `ZikrPagesView` toolbar crash, correct item picker selection equality, clamp invalid content size values, centralize the counter onboarding key, and remove dead debug code

## Verification
- `scripts/swiftlint.sh` (passes with one pre-existing warning in `Azkar/Sources/Library/AppDeepLink.swift`)
- `git diff --check release/2.9.9..HEAD`

## Skipped Work
- skipped duplicate toolbar-label branch `JAW-27-add-accessibility-labels-to-toolbar-buttons` because it duplicated the changes already included from `JAW-14-azkar-ios-improvements`
- skipped `.supacode` worktrees because they were stale/divergent from `release/2.9.9`, dirty, or too broad for this release PR
