### PR TITLE
Ship additional improvements from isolated worktrees

### DIFF
--- a/Azkar/Sources/AzkarApp.swift
+++ b/Azkar/Sources/AzkarApp.swift
@@ -187,17 +187,6 @@ struct AzkarApp: App {
         }
     }
     
-    private func setNavigationControllerAppearance(
-        navigationController: UINavigationController,
-        standardAppearance: UINavigationBarAppearance,
-        scrollEdgeAppearance: UINavigationBarAppearance,
-        tintColor: UIColor
-    ) {
-        navigationController.navigationBar.standardAppearance = standardAppearance
-        navigationController.navigationBar.scrollEdgeAppearance = scrollEdgeAppearance
-        navigationController.navigationBar.tintColor = tintColor
-    }
-
     private func getFont(customName: String?, style: UIFont.TextStyle, design: UIFontDescriptor.SystemDesign) -> UIFont {
         let systemFont = UIFont.preferredFont(forTextStyle: style)
         let font: UIFont

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
@@ -140,7 +140,7 @@ struct MainMenuView: View {
         } else {
             SearchResultsView(
                 viewModel: viewModel.searchViewModel,
-                onSelect: viewModel.naviateToSearchResult(_:)
+                onSelect: viewModel.navigateToSearchResult(_:)
             )
         }
     }

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
@@ -223,7 +223,7 @@ final class MainMenuViewModel: ObservableObject {
         navigator.showArticle(article)
     }
     
-    func naviateToSearchResult(_ searchResult: SearchResultZikr) {
+    func navigateToSearchResult(_ searchResult: SearchResultZikr) {
         navigator.showSearchResult(searchResult, query: searchQuery)
     }
 


### PR DESCRIPTION
## Summary

Cherry-picks two additional completed commits from isolated worktrees that were not included in the previous PRs:

- Remove dead code `setNavigationControllerAppearance` in AzkarApp.swift
- Fix typo: `naviateToSearchResult` -> `navigateToSearchResult`

## Worktrees Reviewed

All 28 sibling worktrees were inspected. The following were excluded:

| Worktree | Reason |
|----------|--------|
| JAW-34-azkar-ios-prs | Already has open PR #112 |
| JAW-40-azkar-ios-prs | Closed; contents superseded by PR #112 |
| JAW-35-azkar-ios-prs | Closed; similar commits to JAW-34 |
| JAW-30/31/32/33-azkar-ios-prs | No unique commits beyond base |
| JAW-5/6/7/8-azkar-ios-improvements | Commits already covered in PR #112 |
| JAW-11/12/14/16/17/19/20/22/24/26/28-azkar-ios-improvements | Commits already covered in PR #112 |
| JAW-36/37-azkar-ios-improvements | No unique commits beyond base |
| JAW-38-azkar-ios-improvements | Has f6b54f9 but similar fix (4b03171) already in PR #112 |

## Commits Cherry-Picked

1. `c2f890b` - Remove dead code `setNavigationControllerAppearance` in AzkarApp.swift
2. `576f576` - Fix typo: `naviateToSearchResult` -> `navigateToSearchResult`

## Skipped

- `f6b54f9` (JAW-38) - Similar crash fix already covered by `4b03171` in PR #112

## Verification

- Branch pushed successfully
- No conflicts during cherry-pick
- Working tree clean