### PR TITLE
Fix force unwrap in Player.playAudio

### DIFF
--- a/Azkar/Sources/Services/Player.swift
+++ b/Azkar/Sources/Services/Player.swift
@@ -100,7 +100,9 @@ final class Player: NSObject, ObservableObject {
     }
 
     func playAudio(_ url: URL, title: String, subtitle: String?) {
-        let item = AudioItem(highQualitySoundURL: url)!
+        guard let item = AudioItem(highQualitySoundURL: url) else {
+            return
+        }
         item.title = title
         item.artist = subtitle
         playItem(item)


### PR DESCRIPTION
## Summary

Cherry-picks a crash fix from an isolated worktree that was not included in previous PRs.

## Changes

- : Replace force unwrap with guard-let-else to prevent potential crash if AudioItem initialization fails.

## Worktrees Reviewed

| Worktree | Reason |
|----------|--------|
| JAW-46-azkar-ios-prs | Already covered by PR #114 |
| JAW-49-release-notes-2.9.9 | Already covered by PR #115 |
| JAW-51-azkar-ios-prs | No unique commits |
| JAW-52-azkar-ios-improvements | Duplicate of commits in PR #116 |
| JAW-54-azkar-ios-prs | Already covered by PR #116 |
| JAW-55-azkar-ios-improvements | **Cherry-picked** - unique commit |

## Notes

- Only 1 new commit was found that wasn't covered by existing PRs.
- Working tree clean after cherry-pick.