### PR TITLE
Fix typo: naviateToSearchResult -> navigateToSearchResult

### DIFF
--- a/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
@@ -141,7 +141,7 @@ struct MainMenuView: View {
         } else {
             SearchResultsView(
                 viewModel: viewModel.searchViewModel,
-                onSelect: viewModel.naviateToSearchResult(_:)
+                onSelect: viewModel.navigateToSearchResult(_:)
             )
         }
     }

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
@@ -215,7 +215,7 @@ final class MainMenuViewModel: ObservableObject {
         navigator.showArticle(article)
     }
     
-    func naviateToSearchResult(_ searchResult: SearchResultZikr) {
+    func navigateToSearchResult(_ searchResult: SearchResultZikr) {
         navigator.showSearchResult(searchResult, query: searchQuery)
     }
 


### PR DESCRIPTION
## Summary

Fixed misspelled function name `naviateToSearchResult` -> `navigateToSearchResult` in MainMenuViewModel and updated the corresponding call site in MainMenuView.

## Changes

- `MainMenuViewModel.swift`: Renamed function from `naviateToSearchResult` to `navigateToSearchResult`
- `MainMenuView.swift`: Updated call site to use the corrected function name

## Verification

- Swiftlint passed with 0 violations on changed files