### PR TITLE
Fix ContentSizeCategory to include .accessibilityExtraLarge (XL+)

### DIFF
--- a/Packages/Core/Sources/Extensions/ContentSizeCategory.swift
+++ b/Packages/Core/Sources/Extensions/ContentSizeCategory.swift
@@ -91,6 +91,7 @@ extension ContentSizeCategory: Codable {
             .extraExtraLarge,
             .accessibilityMedium,
             .accessibilityLarge,
+            .accessibilityExtraLarge,
             .accessibilityExtraExtraLarge
         ]
     }


### PR DESCRIPTION
## Summary

- Fixes `ContentSizeCategory.availableCases` to include `.accessibilityExtraLarge` (XL+)
- Previously the array jumped from `.accessibilityLarge` (L+) directly to `.accessibilityExtraExtraLarge` (XXL+), skipping XL+
- This caused the `bigger()` function to skip XL+ when incrementing from L+

## Change

- `Packages/Core/Sources/Extensions/ContentSizeCategory.swift`: Added `.accessibilityExtraLarge` to `availableCases` array

## Testing

- Verified the change through code review
- The fix ensures proper sequential navigation through all accessibility sizes

Closes JAW-64