### PR TITLE
Fix typo: naviateToSearchResult -> navigateToSearchResult

### DIFF
--- a/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
@@ -141,7 +141,7 @@ struct MainMenuView: View {
         } else {
             SearchResultsView(
                 viewModel: viewModel.searchViewModel,
-                onSelect: viewModel.naviateToSearchResult(_:)
+                onSelect: viewModel.navigateToSearchResult(_:)
             )
         }
     }

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
@@ -215,7 +215,7 @@ final class MainMenuViewModel: ObservableObject {
         navigator.showArticle(article)
     }
     
-    func naviateToSearchResult(_ searchResult: SearchResultZikr) {
+    func navigateToSearchResult(_ searchResult: SearchResultZikr) {
         navigator.showSearchResult(searchResult, query: searchQuery)
     }
 


### PR DESCRIPTION
## Summary

- Fix typo in method name: `naviateToSearchResult` → `navigateToSearchResult`
- Updated method definition and call site

## Files Changed

- `Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift`
- `Azkar/Sources/Scenes/Main Menu/MainMenuView.swift`