### PR TITLE
Fix typo: naviateToSearchResult -> navigateToSearchResult

### DIFF
--- a/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
@@ -215,7 +215,7 @@ final class MainMenuViewModel: ObservableObject {
         navigator.showArticle(article)
     }
     
-    func naviateToSearchResult(_ searchResult: SearchResultZikr) {
+    func navigateToSearchResult(_ searchResult: SearchResultZikr) {
         navigator.showSearchResult(searchResult, query: searchQuery)
     }
 


### PR DESCRIPTION
## Summary
- Fixed typo in method name:  -> 
- The ViewModel method had a typo that didn't match the call site in MainMenuView

## Files changed
-  (1 line)