### PR TITLE
Add accessibility label to article buttons in MainMenuView

### DIFF
--- a/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
@@ -278,6 +278,7 @@ struct MainMenuView: View {
                         imageMaxHeight: articleCellHeight
                     )
                 })
+                .accessibilityLabel(article.title)
                 .applyTheme()
                 .padding(.horizontal, 20)
             }


### PR DESCRIPTION
## Summary

- Add accessibility label to article buttons in MainMenuView so VoiceOver users can identify articles by their title

## Change

Added  to the article buttons in the  computed property of .

## Verification

- Build succeeded with only a pre-existing cyclomatic complexity warning

## Risks

- Minimal - purely additive accessibility improvement

## Related

- Part of ongoing accessibility improvements (see JAW-66, JAW-65)