### PR TITLE
Remove force unwrap in Player.playAudio

### DIFF
--- a/Azkar/Sources/Services/Player.swift
+++ b/Azkar/Sources/Services/Player.swift
@@ -100,7 +100,7 @@ final class Player: NSObject, ObservableObject {
     }
 
     func playAudio(_ url: URL, title: String, subtitle: String?) {
-        let item = AudioItem(highQualitySoundURL: url)!
+        guard let item = AudioItem(highQualitySoundURL: url) else { return }
         item.title = title
         item.artist = subtitle
         playItem(item)


### PR DESCRIPTION
## Summary

- Remove force unwrap in `Player.playAudio` that could cause a crash if the URL is invalid

## Change

Changed `let item = AudioItem(highQualitySoundURL: url)!` to use `guard let` pattern for safe unwrap.

## Verification

- Build succeeded

## Risks

- Minimal - defensive coding improvement

## Related

- Follows pattern from JAW-60 force unwrap fix