### PR TITLE
Add .accessibilityExtraLarge (XL+) to ContentSizeCategory availableCases

### DIFF
--- a/Packages/Core/Sources/Extensions/ContentSizeCategory.swift
+++ b/Packages/Core/Sources/Extensions/ContentSizeCategory.swift
@@ -91,6 +91,7 @@ extension ContentSizeCategory: Codable {
             .extraExtraLarge,
             .accessibilityMedium,
             .accessibilityLarge,
+            .accessibilityExtraLarge,
             .accessibilityExtraExtraLarge
         ]
     }


### PR DESCRIPTION
## Summary

Added `.accessibilityExtraLarge` (XL+) to the `availableCases` array in `ContentSizeCategory`.

Previously, the `availableCases` array jumped from `.accessibilityLarge` (L+) directly to `.accessibilityExtraExtraLarge` (XXL+), skipping `.accessibilityExtraLarge` (XL+). This caused the `bigger()` function to skip XL+ when incrementing from L+.

## Changes

- `Packages/Core/Sources/Extensions/ContentSizeCategory.swift`: Added `.accessibilityExtraLarge` to `availableCases` array (line 94)

## Testing

- Built successfully with `xcodebuild`

## Related

- Issue: [JAW-70]()