### PR TITLE
Add accessibility label and value to category chip button

### DIFF
--- a/Azkar/Sources/Scenes/Settings/Appearance/AppearanceScreen.swift
+++ b/Azkar/Sources/Scenes/Settings/Appearance/AppearanceScreen.swift
@@ -136,8 +136,10 @@ struct AppearanceScreen: View {
             .overlay(RoundedRectangle(cornerRadius: 16).strokeBorder(borderColor, lineWidth: 1.5))
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(Text(category.title))
+        .accessibilityValue(isSelected ? String(localized: "accessibility.common.selected") : String(localized: "accessibility.common.not-selected"))
     }
-
+    
     private func infoButton(_ text: LocalizedStringKey) -> some View {
         Templates.Menu {
             Text(text)


### PR DESCRIPTION
## Summary

Add accessibilityLabel and accessibilityValue to the category chip button in AppearanceScreen to improve VoiceOver support.

## Changes

- Added `.accessibilityLabel(Text(category.title))` to announce the category name
- Added `.accessibilityValue()` to indicate whether the category is selected or not

## Verification

- Build succeeded on iOS Simulator (iPhone 15, iOS 17.5)
- SwiftLint passed

## Related

Part of ongoing accessibility improvements (see JAW-68 for similar work on MainMenuView)