### PR TITLE
Remove debug print statement from NotificationsHandler

### DIFF
--- a/Azkar/Sources/Services/NotificationsHandler.swift
+++ b/Azkar/Sources/Services/NotificationsHandler.swift
@@ -228,7 +228,7 @@ extension NotificationsHandler: MessagingDelegate {
     }
     
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        print(#function, fcmToken as Any)
+        // Token refresh handling is not needed for FCM APNs integration
     }
         
 }


### PR DESCRIPTION
## Summary

- Remove debug print statement from NotificationsHandler.didReceiveRegistrationToken
- Replace with a comment explaining why token refresh handling is not needed for FCM APNs integration

## Change

Removed print(#function, fcmToken as Any) from the messaging(_:didReceiveRegistrationToken:) delegate method.

## Verification

- Build check (swiftlint passed with no new issues)
- Single file change, minimal risk

## Risks

- Minimal - removal of debug code only