### PR TITLE
Remove debug print from SearchSuggestionsViewModel

### DIFF
--- a/Azkar/Sources/Scenes/SearchSuggestions/SearchSuggestionsViewModel.swift
+++ b/Azkar/Sources/Scenes/SearchSuggestions/SearchSuggestionsViewModel.swift
@@ -62,7 +62,7 @@ final class SearchSuggestionsViewModel: ObservableObject {
                     try azkarDatabase.getZikr(record.zikrId, language: record.language)
                 }
         } catch {
-            print(error.localizedDescription)
+            // Error loading suggestions - silently ignore
         }
     }
     


### PR DESCRIPTION
## Summary

- Removed debug print statement from SearchSuggestionsViewModel
- Replaced with silent catch block

## Verification

- Build succeeded with no errors