### PR TITLE
Remove debug print statements from production code

### DIFF
--- a/Azkar/Sources/Services/NotificationsHandler.swift
+++ b/Azkar/Sources/Services/NotificationsHandler.swift
@@ -228,7 +228,6 @@ extension NotificationsHandler: MessagingDelegate {
     }
     
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        print(#function, fcmToken as Any)
     }
         
 }

--- a/Azkar/Sources/Services/ReadingActivityManager.swift
+++ b/Azkar/Sources/Services/ReadingActivityManager.swift
@@ -81,7 +81,6 @@ actor ReadingActivityManager {
             currentSessionID = sessionID
             return sessionID
         } catch {
-            print("Failed to start Live Activity: \(error)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary

Removed debug print statements from two files:
- `NotificationsHandler.swift`: Removed `print(#function, fcmToken as Any)`
- `ReadingActivityManager.swift`: Removed `print("Failed to start Live Activity: \(error)")`

Both were debug code inadvertently left in production.

## Change

- Removed 2 debug print statements
- SwiftLint passes on both files

## Verification

- SwiftLint passed (0 violations, 0 serious)
- Single file changes, minimal risk

## Risks

- Minimal - removal of debug code only