### PR TITLE
Remove debug print statement from SearchManager

### DIFF
--- a/Azkar/Sources/Scenes/Search Results/SearchManager.swift
+++ b/Azkar/Sources/Scenes/Search Results/SearchManager.swift
@@ -58,7 +58,6 @@ final class SearchManager {
                 languages: languages
             )
         } catch {
-            print(error.localizedDescription)
             return []
         }
     }


### PR DESCRIPTION
## Summary

Removed debug print statement from `SearchManager.executeSearch` error handler.

## Change

- Removed `print(error.localizedDescription)` from the catch block in `executeSearch`
- Error handling already returns an empty array, so the print was redundant debug code

## Verification

- SwiftLint passes on the changed file (0 serious violations)
- Single file change, minimal risk

## Risks

- Minimal - removal of debug code only