### PR TITLE
Remove debug print from NotificationsHandler.messaging

### DIFF
--- a/Azkar/Sources/Services/NotificationsHandler.swift
+++ b/Azkar/Sources/Services/NotificationsHandler.swift
@@ -228,7 +228,6 @@ extension NotificationsHandler: MessagingDelegate {
     }
     
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        print(#function, fcmToken as Any)
     }
         
 }


### PR DESCRIPTION
## Summary
- Removed debug print statement from 

## Verification
- Code review: change is minimal and isolated
- Build: unable to verify (UIKit module error in environment)

## Risks
- None: removing dead debug logging code

## Related
- Follows pattern from JAW-72, JAW-73, JAW-74, JAW-75 which removed similar debug prints