### PR TITLE
Remove debug print statement from ZikrViewModel.completeCounter

### DIFF
--- a/Azkar/Sources/Scenes/Zikr View/ZikrViewModel.swift
+++ b/Azkar/Sources/Scenes/Zikr View/ZikrViewModel.swift
@@ -316,7 +316,7 @@ final class ZikrViewModel: ObservableObject, Identifiable, Hashable {
             remainingRepeatsNumber = 0
             updateRemainingRepeatsText()
         } catch {
-            print(error)
+            // Handle error silently
         }
     }
     


### PR DESCRIPTION
## Summary

- Remove debug `print(error)` statement from `ZikrViewModel.completeCounter()` error handler

## Changes

- `Azkar/Sources/Scenes/Zikr View/ZikrViewModel.swift`: Removed debug print in catch block

## Verification

- Build succeeded on iOS Simulator