### PR TITLE
Remove debug print statements from FontsHelper

### DIFF
--- a/Azkar/Sources/Library/FontsHelper.swift
+++ b/Azkar/Sources/Library/FontsHelper.swift
@@ -16,9 +16,7 @@ enum FontsHelper {
             for subdirectory in subdirectories {
                 registerFonts(in: subdirectory)
             }
-        } catch {
-            print(error)
-        }
+        } catch {}
     }
     
     static func registerFonts(_ urls: [URL]) {
@@ -32,9 +30,7 @@ enum FontsHelper {
             for file in fontFiles {
                 registerFont(at: file)
             }
-        } catch {
-            print(error)
-        }
+        } catch {}
     }
     
     /// Register font at given URL.
@@ -46,9 +42,7 @@ enum FontsHelper {
         if let font = CGFont(provider) {
             CTFontManagerRegisterGraphicsFont(font, &error)
         }
-        if let error = error {
-            print(error)
-        }
+        _ = error
     }
     
     /// Register font at given path.


### PR DESCRIPTION
## Summary
- Remove 3 debug `print` statements from `FontsHelper.swift`
- Two in font directory enumeration catch blocks, one in font registration error handling
- Consistent with the ongoing debug print cleanup across recent PRs

## Verification
- Build succeeds with no new warnings or errors
- No behavioral change — errors are still handled the same way (silently), just without console output