### PR TITLE
Remove force unwraps from AboutApp bundle version lookup

### DIFF
--- a/Azkar/Sources/Scenes/Settings/SettingsFlowView.swift
+++ b/Azkar/Sources/Scenes/Settings/SettingsFlowView.swift
@@ -201,8 +201,8 @@ private struct AboutAppDestinationView: View {
         AppInfoView(
             viewModel: AppInfoViewModel(
                 appVersion: {
-                    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")!
-                    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion")!
+                    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+                    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
                     return "\(String(localized: "common.version")) \(version) (\(build))"
                 }(),
                 isProUser: subscriptionManager.isProUser()


### PR DESCRIPTION
## Summary
- Replace 2 force-unwrapped `Bundle.main.object(forInfoDictionaryKey:)` calls in `SettingsFlowView.swift:204-205` with safe optional casting (`as? String`)
- Use `?? "?"` fallback if the keys are ever missing
- No behavioral change when Info.plist is correct; prevents runtime crash if keys were absent

## Files changed
- `Azkar/Sources/Scenes/Settings/SettingsFlowView.swift` — 2 lines changed

## Verification
- Reviewed that `CFBundleShortVersionString` and `CFBundleVersion` are always present in a valid Xcode project's Info.plist
- Change is purely defensive; output matches prior behavior in normal circumstances

## Context
- Continues the force-unwrap cleanup pattern from earlier PRs (JAW-69, JAW-80)