### PR TITLE
Add accessibility labels to share font size buttons

### DIFF
--- a/Azkar/Resources/Localizable.xcstrings
+++ b/Azkar/Resources/Localizable.xcstrings
@@ -1092,6 +1092,64 @@
         }
       }
     },
+    "accessibility.share.decrease-font-size" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تصغير الخط"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decrease font size"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Уменьшить размер текста"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yazı boyutunu küçült"
+          }
+        }
+      }
+    },
+    "accessibility.share.increase-font-size" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تكبير الخط"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Increase font size"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увеличить размер текста"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yazı boyutunu büyüt"
+          }
+        }
+      }
+    },
     "adhkar-collections.azkar-ru.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Sections.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Sections.swift
@@ -294,5 +294,6 @@ extension ZikrShareOptionsView {
         })
         .buttonStyle(.plain)
         .disabled(isDisabled)
+        .accessibilityLabel(String(localized: increasing ? "accessibility.share.increase-font-size" : "accessibility.share.decrease-font-size"))
     }
 }


### PR DESCRIPTION
## Summary
- Added `.accessibilityLabel` to the increase/decrease font size buttons in the share options view
- Added localized strings (ar, en, ru, tr) for both labels
- VoiceOver users can now identify and use the +/- font size controls in the share screen

## Files changed
- `ZikrShareOptionsView+Sections.swift` — added `.accessibilityLabel` to `fontSizeButton`
- `Localizable.xcstrings` — added `accessibility.share.increase-font-size` and `accessibility.share.decrease-font-size` keys

## Verification
- Diff reviewed for correctness
- No existing open/merged PR covers this specific area