### PR TITLE
Replace deprecated .edgesIgnoringSafeArea() with .ignoresSafeArea()

### DIFF
--- a/Azkar/Sources/Library/NotificationsListView.swift
+++ b/Azkar/Sources/Library/NotificationsListView.swift
@@ -189,7 +189,7 @@ struct NotificationsListView: View {
         .background(.background, ignoreSafeArea: .all)
         .background(
             Text("This view is only visible in test builds")
-                .edgesIgnoringSafeArea(.bottom)
+                .ignoresSafeArea(.bottom)
                 .foregroundStyle(.secondary)
             ,
             alignment: .bottom

--- a/Azkar/Sources/Scenes/Hadith View/HadithView.swift
+++ b/Azkar/Sources/Scenes/Hadith View/HadithView.swift
@@ -33,7 +33,7 @@ struct HadithView: View {
         .onAppear {
             AnalyticsReporter.reportScreen("Hadith View", className: viewName)
         }
-        .background(colorTheme.getColor(.background).edgesIgnoringSafeArea(.all))
+        .background(colorTheme.getColor(.background).ignoresSafeArea())
     }
 
     private func getContent() -> some View {

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
@@ -122,7 +122,7 @@ struct MainMenuView: View {
                             Image("eid_background")
                                 .resizable()
                                 .aspectRatio(contentMode: ContentMode.fill)
-                                .edgesIgnoringSafeArea(.all)
+                                .ignoresSafeArea()
                                 .blendMode(.overlay)
                         }
                     }

--- a/Azkar/Sources/Scenes/Zikr Pages/ZikrPagesView.swift
+++ b/Azkar/Sources/Scenes/Zikr Pages/ZikrPagesView.swift
@@ -85,7 +85,7 @@ struct ZikrPagesView: View, Equatable {
         }
         .initialPageIndex(viewModel.initialPage)
         .currentPageIndex($viewModel.page.animation(.spring))
-        .edgesIgnoringSafeArea(.bottom)
+        .ignoresSafeArea(.bottom)
         .environment(\.zikrReadingMode, readingMode ?? viewModel.preferences.zikrReadingMode)
         .onReceive(viewModel.preferences.$zikrReadingMode) { newMode in
             readingMode = newMode
@@ -104,7 +104,7 @@ struct ZikrPagesView: View, Equatable {
                     pageIndicator(index: idx, isSelected: isSelected)
                 }
             )
-            .edgesIgnoringSafeArea(.bottom)
+            .ignoresSafeArea(.bottom)
         }
         .opacity(viewModel.page < viewModel.pages.count - 1 ? 1 : 0)
         .frame(maxHeight: pageIndicatorHeight + 8)

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareView.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareView.swift
@@ -55,7 +55,7 @@ struct ZikrShareView: View {
     
     var body: some View {
         container
-            .edgesIgnoringSafeArea(.all)
+            .ignoresSafeArea()
             .environment(\.colorScheme, customColorScheme)
             .onAppear {
                 AnalyticsReporter.reportScreen("Zikr Share", className: viewName)


### PR DESCRIPTION
Replaces all 6 occurrences of the deprecated `.edgesIgnoringSafeArea()` modifier with the modern `.ignoresSafeArea()` API across 5 files.

**Files changed:**
- `Azkar/Sources/Scenes/Main Menu/MainMenuView.swift`
- `Azkar/Sources/Scenes/Zikr Share View/ZikrShareView.swift`
- `Azkar/Sources/Scenes/Zikr Pages/ZikrPagesView.swift` (2 occurrences)
- `Azkar/Sources/Scenes/Hadith View/HadithView.swift`
- `Azkar/Sources/Library/NotificationsListView.swift`

**Why:** `.edgesIgnoringSafeArea()` was deprecated in iOS 14. Since the app targets iOS 15+, `.ignoresSafeArea()` is the correct replacement. This is a 1:1 API swap with identical behavior.