### PR TITLE
Add accessibility label to share save/copy button in ZikrShareOptionsView

### DIFF
--- a/Azkar/Resources/Localizable.xcstrings
+++ b/Azkar/Resources/Localizable.xcstrings
@@ -8425,6 +8425,64 @@
         }
       }
     },
+    "share.save-image" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs-translation",
+            "value" : "Save Image"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save Image"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs-translation",
+            "value" : "Save Image"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs-translation",
+            "value" : "Save Image"
+          }
+        }
+      }
+    },
+    "share.copy-text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs-translation",
+            "value" : "Copy Text"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Text"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs-translation",
+            "value" : "Copy Text"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs-translation",
+            "value" : "Copy Text"
+          }
+        }
+      }
+    },
     "subscribe.billing.auto-renewing" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView.swift
@@ -276,6 +276,7 @@ struct ZikrShareOptionsView: View {
             }, label: {
                 Image(systemName: selectedShareType == .image ? "square.and.arrow.down" : "doc.on.doc")
             })
+            .accessibilityLabel(Text(selectedShareType == .image ? "share.save-image" : "share.copy-text"))
             .disabled(processingQuickShareAction != nil)
             .opacity(processingQuickShareAction != nil ? 0.5 : 1)
             


### PR DESCRIPTION
The toolbar save/copy button in ZikrShareOptionsView displayed only a system image (SF Symbol) with no accessibility label. VoiceOver users could not determine this button's purpose.

## Changes

- Added  to the save/copy button that dynamically switches between  and  based on the selected share type
- Added new localization keys  and  (English translated, other languages marked as needs-translation)

## Verification

- Build succeeded with Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild

ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (2 targets)
    Target 'Azkar' in project 'Azkar'
        ➜ Explicit dependency on target 'AzkarWidgets' in project 'Azkar'
    Target 'AzkarWidgets' in project 'Azkar' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/xcstringstool compile --dry-run --output-directory /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/Resources/Localizable.xcstrings

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --print-asset-tag-combinations --output-format xml1 /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar/Resources/Assets.xcassets

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/ibtool --version --output-format xml1

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/xcstringstool compile --dry-run --output-directory /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/Azkar.build /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar/Resources/Localizable.xcstrings

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details

Build description signature: 808f2e2952ab255ef58592e46327fe30
Build description path: /Users/avo/dev/azkar/paperclip-azkar-ios/build/XCBuildData/808f2e2952ab255ef58592e46327fe30.xcbuilddata
ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.4.sdk /var/folders/3w/h5_j53ps53gc7d5b7wly48n80000gs/C/com.apple.DeveloperTools/26.4-17E192/Xcode/SDKStatCaches.noindex/iphoneos26.4-23E237-68a138bb55de9ba35ce6c8c40d12849e.sdkstatcache
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.4.sdk -o /var/folders/3w/h5_j53ps53gc7d5b7wly48n80000gs/C/com.apple.DeveloperTools/26.4-17E192/Xcode/SDKStatCaches.noindex/iphoneos26.4-23E237-68a138bb55de9ba35ce6c8c40d12849e.sdkstatcache

CreateBuildDirectory /Users/avo/dev/azkar/paperclip-azkar-ios/build
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-create-build-directory /Users/avo/dev/azkar/paperclip-azkar-ios/build

CreateBuildDirectory /Users/avo/dev/azkar/paperclip-azkar-ios/build/SwiftExplicitPrecompiledModules
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-create-build-directory /Users/avo/dev/azkar/paperclip-azkar-ios/build/SwiftExplicitPrecompiledModules

CreateBuildDirectory /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-create-build-directory /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos

CreateBuildDirectory /Users/avo/dev/azkar/paperclip-azkar-ios/build/ExplicitPrecompiledModules
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-create-build-directory /Users/avo/dev/azkar/paperclip-azkar-ios/build/ExplicitPrecompiledModules

CreateBuildDirectory /Users/avo/dev/azkar/paperclip-azkar-ios/build/EagerLinkingTBDs/Release-iphoneos
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-create-build-directory /Users/avo/dev/azkar/paperclip-azkar-ios/build/EagerLinkingTBDs/Release-iphoneos

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/Azkar-e72ac13c6357c5fed0d7b4f055ff9921-VFS-iphoneos/all-product-headers.yaml
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/Azkar-e72ac13c6357c5fed0d7b4f055ff9921-VFS-iphoneos/all-product-headers.yaml

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-all-target-headers.hmap (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-all-target-headers.hmap

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-project-headers.hmap (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-project-headers.hmap

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-all-non-framework-target-headers.hmap (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-all-non-framework-target-headers.hmap

MkDir /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    /bin/mkdir -p /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.hmap (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.hmap

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-own-target-headers.hmap (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-own-target-headers.hmap

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-generated-files.hmap (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets-generated-files.hmap

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/DerivedSources/Entitlements.plist (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/DerivedSources/Entitlements.plist

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets-OutputFileMap.json (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets-OutputFileMap.json

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets_const_extract_protocols.json (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets_const_extract_protocols.json

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets.LinkFileList (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets.LinkFileList

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets.SwiftFileList (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets.SwiftFileList

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets.SwiftConstValuesFileList (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/Objects-normal/arm64/AzkarWidgets.SwiftConstValuesFileList

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.DependencyStaticMetadataFileList (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.DependencyStaticMetadataFileList

WriteAuxiliaryFile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.DependencyMetadataFileList (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    write-file /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.DependencyMetadataFileList

ProcessProductPackaging /Users/avo/Library/Developer/Xcode/UserData/Provisioning\ Profiles/b90275f2-391c-4837-b789-c0a73c80e9c6.mobileprovision /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex/embedded.mobileprovision (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    builtin-productPackagingUtility /Users/avo/Library/Developer/Xcode/UserData/Provisioning\ Profiles/b90275f2-391c-4837-b789-c0a73c80e9c6.mobileprovision -o /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex/embedded.mobileprovision

ProcessProductPackaging /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/AzkarWidgets.entitlements /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.appex.xcent (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    
    Entitlements:
    
    {
    "application-identifier" = "2VFCBFYPFW.io.jawziyya.azkar-app.widgets";
    "beta-reports-active" = 1;
    "com.apple.developer.team-identifier" = 2VFCBFYPFW;
    "com.apple.security.application-groups" =     (
        "group.io.jawziyya.azkar-app"
    );
    "get-task-allow" = 0;
}
    
    builtin-productPackagingUtility /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/AzkarWidgets.entitlements -entitlements -format xml -o /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.appex.xcent

ProcessProductPackagingDER /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.appex.xcent /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.appex.xcent.der (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    /usr/bin/derq query -f xml -i /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.appex.xcent -o /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/AzkarWidgets.appex.xcent.der --raw

ProcessXCFramework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/google-ads-on-device-conversion-ios-sdk/GoogleAdsOnDeviceConversion/GoogleAdsOnDeviceConversion.xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/GoogleAdsOnDeviceConversion.framework ios
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-process-xcframework --xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/google-ads-on-device-conversion-ios-sdk/GoogleAdsOnDeviceConversion/GoogleAdsOnDeviceConversion.xcframework --platform ios --target-path /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos --expected-signature AppleDeveloperProgram:EQHXZ8M8AV:Google\ LLC

ProcessXCFramework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/googleappmeasurement/GoogleAppMeasurementIdentitySupport/GoogleAppMeasurementIdentitySupport.xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/GoogleAppMeasurementIdentitySupport.framework ios
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-process-xcframework --xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/googleappmeasurement/GoogleAppMeasurementIdentitySupport/GoogleAppMeasurementIdentitySupport.xcframework --platform ios --target-path /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos --expected-signature AppleDeveloperProgram:EQHXZ8M8AV:Google\ LLC

ProcessXCFramework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/googleappmeasurement/GoogleAppMeasurement/GoogleAppMeasurement.xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/GoogleAppMeasurement.framework ios
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-process-xcframework --xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/googleappmeasurement/GoogleAppMeasurement/GoogleAppMeasurement.xcframework --platform ios --target-path /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos --expected-signature AppleDeveloperProgram:EQHXZ8M8AV:Google\ LLC

MkDir /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_output/thinned (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    /bin/mkdir -p /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_output/thinned

GenerateAssetSymbols /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/Resources/Assets.xcassets (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    /Applications/Xcode.app/Contents/Developer/usr/bin/actool /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/Resources/Assets.xcassets --compile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex --output-format human-readable-text --notices --warnings --export-dependency-info /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_dependencies --output-partial-info-plist /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_generated_info.plist --include-all-app-icons --compress-pngs --enable-on-demand-resources NO --standalone-icon-behavior all --development-region en --target-device iphone --target-device ipad --minimum-deployment-target 15.0 --platform iphoneos --bundle-identifier io.jawziyya.azkar-app.widgets --generate-swift-asset-symbol-extensions NO --generate-swift-asset-symbols /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/DerivedSources/GeneratedAssetSymbols.swift --generate-objc-asset-symbols /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/DerivedSources/GeneratedAssetSymbols.h --generate-asset-symbol-index /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/DerivedSources/GeneratedAssetSymbols-Index.plist

CpResource /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex/azkar.db /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar/Resources/azkar.db (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar/Resources/azkar.db /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex

MkDir /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_output/unthinned (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    /bin/mkdir -p /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_output/unthinned

CpResource /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex/GRDB_GRDB.bundle /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/GRDB_GRDB.bundle (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/GRDB_GRDB.bundle /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex
error: The file “GRDB_GRDB.bundle” couldn’t be opened because there is no such file. (in target 'AzkarWidgets' from project 'Azkar')

CpResource /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex/Fakery_Fakery.bundle /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/Fakery_Fakery.bundle (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/Fakery_Fakery.bundle /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex
error: The file “Fakery_Fakery.bundle” couldn’t be opened because there is no such file. (in target 'AzkarWidgets' from project 'Azkar')

CompileXCStrings /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/ /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/Resources/Localizable.xcstrings (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcstringstool compile --output-directory /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/Resources/Localizable.xcstrings

ProcessXCFramework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/firebase-ios-sdk/FirebaseAnalytics/FirebaseAnalytics.xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/FirebaseAnalytics.framework ios
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-process-xcframework --xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/firebase-ios-sdk/FirebaseAnalytics/FirebaseAnalytics.xcframework --platform ios --target-path /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos --expected-signature AppleDeveloperProgram:EQHXZ8M8AV:Google\ LLC

CompileAssetCatalogVariant thinned /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/AzkarWidgets.appex /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/Resources/Assets.xcassets (in target 'AzkarWidgets' from project 'Azkar')
    cd /Users/avo/dev/azkar/paperclip-azkar-ios
    /Applications/Xcode.app/Contents/Developer/usr/bin/actool /Users/avo/dev/azkar/paperclip-azkar-ios/AzkarWidgets/Resources/Assets.xcassets --compile /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_output/thinned --output-format human-readable-text --notices --warnings --export-dependency-info /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_dependencies_thinned --output-partial-info-plist /Users/avo/dev/azkar/paperclip-azkar-ios/build/Azkar.build/Release-iphoneos/AzkarWidgets.build/assetcatalog_generated_info.plist_thinned --include-all-app-icons --compress-pngs --enable-on-demand-resources NO --standalone-icon-behavior all --development-region en --target-device iphone --target-device ipad --minimum-deployment-target 15.0 --platform iphoneos

ProcessXCFramework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/lottie-spm/Lottie/Lottie.xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos/Lottie.framework ios
    cd /Users/avo/dev/azkar/paperclip-azkar-ios/Azkar.xcodeproj
    builtin-process-xcframework --xcframework /Users/avo/dev/azkar/paperclip-azkar-ios/Tuist/.build/artifacts/lottie-spm/Lottie/Lottie.xcframework --platform ios --target-path /Users/avo/dev/azkar/paperclip-azkar-ios/build/Release-iphoneos --expected-signature SelfSigned:892F1B43047B50538F2F46EAD92900DD3D4811F3582178C061A5FB20F111CB26

note: Run script build phase 'SwiftLint' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked. (in target 'Azkar' from project 'Azkar') on iPhone 15 Plus simulator
- Pattern matches existing accessibility labels in the codebase (e.g.,  on adjacent button)