### PR TITLE
Add accessibility label to info button in TextSettingsScreen

### DIFF
--- a/Azkar/Sources/Scenes/Settings/Text/TextSettingsScreen.swift
+++ b/Azkar/Sources/Scenes/Settings/Text/TextSettingsScreen.swift
@@ -46,6 +46,7 @@ struct TextSettingsScreen: View {
                         Image(systemName: "info.circle")
                     }
                 )
+                .accessibilityLabel(Text("accessibility.common.more-info"))
                 .padding(.trailing)
             }
             


### PR DESCRIPTION
## Summary

- The info button in the adhkar collections source section uses only an `Image(systemName: "info.circle")` with no accessibility label, making it invisible to VoiceOver users.
- Added `.accessibilityLabel(Text("accessibility.common.more-info"))` matching the existing pattern in `AppearanceScreen`, `ExtraTextSettingsScreen`, and `CounterScreen`.

## Verification

- Confirmed the localization key `accessibility.common.more-info` exists in `Localizable.xcstrings`.
- Confirmed the same pattern is used in 3 other settings screens in this codebase.