### PR TITLE
Remove force unwraps of self.view in GSTouchesShowingGestureRecognizer

### DIFF
--- a/Azkar/Sources/Library/GSTouchesShowingWindow/GSTouchesShowingGestureRecognizer.swift
+++ b/Azkar/Sources/Library/GSTouchesShowingWindow/GSTouchesShowingGestureRecognizer.swift
@@ -20,26 +20,30 @@ public class GSTouchesShowingGestureRecognizer: UIGestureRecognizer, UIGestureRe
     }
     
     override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard let view = self.view else { return }
         for touch in touches {
-            self.touchesShowingController.touchBegan(touch, view: self.view!)
+            self.touchesShowingController.touchBegan(touch, view: view)
         }
     }
-    
+
     override public func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard let view = self.view else { return }
         for touch in touches {
-            self.touchesShowingController.touchMoved(touch, view: self.view!)
+            self.touchesShowingController.touchMoved(touch, view: view)
         }
     }
-    
+
     override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard let view = self.view else { return }
         for touch in touches {
-            self.touchesShowingController.touchEnded(touch, view: self.view!)
+            self.touchesShowingController.touchEnded(touch, view: view)
         }
     }
-    
+
     override public func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard let view = self.view else { return }
         for touch in touches {
-            self.touchesShowingController.touchEnded(touch, view: self.view!)
+            self.touchesShowingController.touchEnded(touch, view: view)
         }
     }
     


### PR DESCRIPTION
## Change

Replaced `self.view!` force unwraps with `guard let` in all four touch event handlers (`touchesBegan`, `touchesMoved`, `touchesEnded`, `touchesCancelled`) in `GSTouchesShowingGestureRecognizer.swift`.

## Why

`UIGestureRecognizer.view` returns an optional. If the gesture recognizer is detached from a view when a touch event arrives, the force unwrap would crash. The guard-let gracefully skips the event instead.

## Verification

- Single-file change, same types and control flow
- No behavioral change in the normal case (view is non-nil)