### PR TITLE
Replace deprecated .accentColor() with .tint()

### DIFF
--- a/Azkar/Sources/Scenes/Settings/Fonts/FontsListItemView.swift
+++ b/Azkar/Sources/Scenes/Settings/Fonts/FontsListItemView.swift
@@ -38,7 +38,7 @@ struct FontsListItemView: View {
             
             if let imageURL = vm.imageURL {
                 FontsListItemView.fontImageView(imageURL, isRedacted: isRedacted)
-                    .accentColor(colorTheme.getColor(.accent))
+                    .tint(colorTheme.getColor(.accent))
                     .frame(width: 100, height: 40)
                     .foregroundStyle(.accent)
                     .onTapGesture(perform: selectionCallback)

--- a/Packages/Modules/Sources/ArticleReader/ArticleHeaderView.swift
+++ b/Packages/Modules/Sources/ArticleReader/ArticleHeaderView.swift
@@ -18,7 +18,7 @@ extension Article.ImageType {
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .accentColor(Color.primary)
+                        .tint(Color.primary)
                 } else if state.isLoading {
                     Color(.systemBackground)
                         .overlay {
@@ -34,7 +34,7 @@ extension Article.ImageType {
             Image(name)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
-                .accentColor(Color.primary)
+                .tint(Color.primary)
                 .frame(minWidth: 0, maxHeight: maxHeight)
             
         }


### PR DESCRIPTION
Replaces all 3 occurrences of the deprecated `.accentColor()` modifier with `.tint()` across 2 files.

- `ArticleHeaderView.swift` — 2 call sites (lines 21, 37)
- `FontsListItemView.swift` — 1 call site (line 41)

`.accentColor()` was deprecated in iOS 15 in favor of `.tint()`. Both APIs have identical behavior on iOS 15+, which is the app's minimum deployment target.