### PR TITLE
Fix typo: resourcesBunbdle -> resourcesBundle

### DIFF
--- a/Azkar/Sources/Library/GSTouchesShowingWindow/GSTouchesShowingController.swift
+++ b/Azkar/Sources/Library/GSTouchesShowingWindow/GSTouchesShowingController.swift
@@ -134,7 +134,7 @@ class GSTouchImageViewQueue {
         
         let bundle = Bundle(for: type(of: self))
         for _ in 0..<touchesCount {
-            let imageView = UIImageView(image: UIImage(named: CONSTANTS.TouchImageName, in: resourcesBunbdle, compatibleWith: nil))
+            let imageView = UIImageView(image: UIImage(named: CONSTANTS.TouchImageName, in: resourcesBundle, compatibleWith: nil))
             self.backingArray.append(imageView)
         }
     }

--- a/Azkar/Sources/Library/Typealiases.swift
+++ b/Azkar/Sources/Library/Typealiases.swift
@@ -6,4 +6,4 @@ import AzkarResources
 
 typealias AnalyticsReporter = AzkarServices.AnalyticsReporter
 
-let resourcesBunbdle = azkarResourcesBundle
+let resourcesBundle = azkarResourcesBundle

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
@@ -107,7 +107,7 @@ final class MainMenuViewModel: ObservableObject {
                 title: String(localized: "category.night"),
                 color: Color.init(uiColor: .systemMint),
                 count: nil,
-                iconType: .bundled(resourcesBunbdle)
+                iconType: .bundled(resourcesBundle)
             ),
             AzkarMenuItem(
                 category: .afterSalah,
@@ -115,7 +115,7 @@ final class MainMenuViewModel: ObservableObject {
                 title: String(localized: "category.after-salah"),
                 color: Color.init(.systemBlue),
                 count: nil,
-                iconType: .bundled(resourcesBunbdle)
+                iconType: .bundled(resourcesBundle)
             ),
             AzkarMenuItem(
                 category: .other,
@@ -123,7 +123,7 @@ final class MainMenuViewModel: ObservableObject {
                 title: String(localized: "category.other"),
                 color: Color.init(.systemTeal),
                 count: nil,
-                iconType: .bundled(resourcesBunbdle)
+                iconType: .bundled(resourcesBundle)
             ),
             AzkarMenuItem(
                 category: .hundredDua,
@@ -131,7 +131,7 @@ final class MainMenuViewModel: ObservableObject {
                 title: String(localized: "category.hundred-dua"),
                 color: Color.init(.systemPink),
                 count: nil,
-                iconType: .bundled(resourcesBunbdle)
+                iconType: .bundled(resourcesBundle)
             ),
         ]
 

--- a/Azkar/Sources/Scenes/Root/ArticleShareActionHandler.swift
+++ b/Azkar/Sources/Scenes/Root/ArticleShareActionHandler.swift
@@ -27,7 +27,7 @@ final class ArticleShareActionHandler {
             textFont: UIFont(name: preferences.preferredTranslationFont.postscriptName, size: 25)!,
             pageMargins: UIEdgeInsets(horizontal: 75, vertical: 65),
             footer: ArticlePDFComposer.Footer(
-                image: UIImage(named: "ink-icon", in: resourcesBunbdle, compatibleWith: nil),
+                image: UIImage(named: "ink-icon", in: resourcesBundle, compatibleWith: nil),
                 text: String(localized: "share.shared-with-azkar").uppercased(),
                 link: URL(string: "https://apple.co/41O1pzQ")
             )
@@ -47,7 +47,7 @@ final class ArticleShareActionHandler {
         let view = ArticlePDFCoverView(
             article: article,
             maxHeight: 842,
-            logoImage: UIImage(named: "ink-icon", in: resourcesBunbdle, compatibleWith: nil),
+            logoImage: UIImage(named: "ink-icon", in: resourcesBundle, compatibleWith: nil),
             logoSubtitle: String(localized: "share.shared-with-azkar")
         )
         .frame(width: 595, height: 842)

--- a/Azkar/Sources/Scenes/Settings/App Icons View/AppIconPackListView.swift
+++ b/Azkar/Sources/Scenes/Settings/App Icons View/AppIconPackListView.swift
@@ -114,7 +114,7 @@ struct AppIconPackListView: View {
     
     func iconView(for icon: AppIcon, position: IndexPosition) -> some View {
         HStack(spacing: 16) {
-            if let image = UIImage(named: icon.iconImageName, in: resourcesBunbdle, compatibleWith: nil) {
+            if let image = UIImage(named: icon.iconImageName, in: resourcesBundle, compatibleWith: nil) {
                 Image(uiImage: image)
                     .resizable()
                     .scaledToFit()

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareBackgroundItem.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareBackgroundItem.swift
@@ -43,7 +43,7 @@ extension ZikrShareBackgroundItem {
         imageNames.map {
             ZikrShareBackgroundItem(
                 id: $0.imageName,
-                background: .localImage(UIImage(named: "Patterns/" + $0.imageName, in: resourcesBunbdle, with: nil)!),
+                background: .localImage(UIImage(named: "Patterns/" + $0.imageName, in: resourcesBundle, with: nil)!),
                 type: $0.type,
                 isProItem: false
             )

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareView.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareView.swift
@@ -163,7 +163,7 @@ struct ZikrShareView: View {
 
             if includeLogo {
                 VStack {
-                    if let image = UIImage(named: "ink-icon", in: resourcesBunbdle, compatibleWith: nil) {
+                    if let image = UIImage(named: "ink-icon", in: resourcesBundle, compatibleWith: nil) {
                         Image(uiImage: image)
                             .renderingMode(.template)
                             .resizable()


### PR DESCRIPTION
Fixes the misspelled internal constant `resourcesBunbdle` → `resourcesBundle` in the definition and all 11 call sites across 7 files.

This is a pure rename with no behavioral change.