### PR TITLE
Remove force unwraps in ContentSizeCategory bigger/smaller

### DIFF
--- a/Packages/Core/Sources/Extensions/ContentSizeCategory.swift
+++ b/Packages/Core/Sources/Extensions/ContentSizeCategory.swift
@@ -97,14 +97,14 @@ extension ContentSizeCategory: Codable {
     
     public func bigger() -> ContentSizeCategory {
         let all = ContentSizeCategory.availableCases
-        let index = all.firstIndex(of: self)!
+        guard let index = all.firstIndex(of: self) else { return self }
         let nextIndex = min(all.count - 1, index + 1)
         return all[nextIndex]
     }
-    
+
     public func smaller() -> ContentSizeCategory {
         let all = ContentSizeCategory.availableCases
-        let index = all.firstIndex(of: self)!
+        guard let index = all.firstIndex(of: self) else { return self }
         let prevIndex = max(0, index - 1)
         return all[prevIndex]
     }


### PR DESCRIPTION
The `bigger()` and `smaller()` methods force-unwrapped `firstIndex(of:)`, which would crash if `self` is not in `availableCases` (e.g. `.extraSmall` or `.accessibilityExtraExtraExtraLarge`). Use `guard-let` to safely return `self` when the index is not found, avoiding the crash while keeping the current size category unchanged.