### PR TITLE
Fix typo: isCheked -> isChecked in CheckboxView

### DIFF
--- a/Azkar/Sources/Scenes/Item Picker/ItemPickerView.swift
+++ b/Azkar/Sources/Scenes/Item Picker/ItemPickerView.swift
@@ -73,7 +73,7 @@ struct ItemPickerView<SelectionValue>: View where SelectionValue: Hashable & Ide
                         ProBadgeView()
                             .accessibilityHidden(true)
                     } else {
-                        CheckboxView(isCheked: .constant(isSelected))
+                        CheckboxView(isChecked: .constant(isSelected))
                             .frame(width: 20, height: 20)
                             .accessibilityHidden(true)
                     }

--- a/Azkar/Sources/Scenes/Settings/App Icons View/AppIconPackListView.swift
+++ b/Azkar/Sources/Scenes/Settings/App Icons View/AppIconPackListView.swift
@@ -130,7 +130,7 @@ struct AppIconPackListView: View {
             Spacer()
             
             if viewModel.icon == icon || viewModel.isIconAvailable(icon) {
-                CheckboxView(isCheked:  .constant(self.viewModel.icon.referenceName == icon.referenceName))
+                CheckboxView(isChecked:  .constant(self.viewModel.icon.referenceName == icon.referenceName))
                     .frame(width: 20, height: 20)
             } else {
                 ProBadgeView()

--- a/Azkar/Sources/Scenes/Settings/Fonts/FontsListItemView.swift
+++ b/Azkar/Sources/Scenes/Settings/Fonts/FontsListItemView.swift
@@ -45,7 +45,7 @@ struct FontsListItemView: View {
             }
             
             if hasAccessToFont || isSelectedFont {
-                CheckboxView(isCheked: .constant(isSelectedFont))
+                CheckboxView(isChecked: .constant(isSelectedFont))
                     .frame(width: 20, height: 20)
             } else {
                 ProBadgeView()

--- a/Azkar/Sources/Scenes/Settings/Reminders/Sound Picker/ReminderSoundPickerView.swift
+++ b/Azkar/Sources/Scenes/Settings/Reminders/Sound Picker/ReminderSoundPickerView.swift
@@ -51,7 +51,7 @@ struct ReminderSoundPickerView: View {
                 Spacer()
 
                 if hasAccess || isSelected {
-                    CheckboxView(isCheked: .constant(isSelected))
+                    CheckboxView(isChecked: .constant(isSelected))
                         .frame(width: 20, height: 20)
                 } else {
                     ProBadgeView()

--- a/Packages/Modules/Sources/Library/Views/CheckboxView.swift
+++ b/Packages/Modules/Sources/Library/Views/CheckboxView.swift
@@ -2,16 +2,16 @@ import SwiftUI
 
 public struct CheckboxView: View {
 
-    @Binding var isCheked: Bool
+    @Binding var isChecked: Bool
     @Environment(\.appTheme) var appTheme
     @Environment(\.colorTheme) var colorTheme
     
-    public init(isCheked: Binding<Bool>) {
-        _isCheked = isCheked
+    public init(isChecked: Binding<Bool>) {
+        _isChecked = isChecked
     }
 
     public var body: some View {
-        if isCheked {
+        if isChecked {
             Image(systemName: "checkmark")
                 .resizable()
                 .scaledToFit()
@@ -29,23 +29,23 @@ public struct CheckboxView: View {
         Group {
             if appTheme.cornerRadius > 0 {
                 Circle()
-                    .strokeBorder(isCheked ? colorTheme.getColor(.accent) : Color.gray, lineWidth: 1.5)
-                    .background(isCheked ? Circle().fill(colorTheme.getColor(.accent)) : nil)
+                    .strokeBorder(isChecked ? colorTheme.getColor(.accent) : Color.gray, lineWidth: 1.5)
+                    .background(isChecked ? Circle().fill(colorTheme.getColor(.accent)) : nil)
             } else {
                 Rectangle()
-                    .strokeBorder(isCheked ? colorTheme.getColor(.accent) : Color.gray, lineWidth: 1.5)
-                    .background(isCheked ? Rectangle().fill(colorTheme.getColor(.accent)) : nil)
+                    .strokeBorder(isChecked ? colorTheme.getColor(.accent) : Color.gray, lineWidth: 1.5)
+                    .background(isChecked ? Rectangle().fill(colorTheme.getColor(.accent)) : nil)
             }
         }
-        .foregroundStyle(isCheked ? .accent : .text)
+        .foregroundStyle(isChecked ? .accent : .text)
     }
 }
 
 struct CheckboxView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            CheckboxView(isCheked: .constant(true))
-            CheckboxView(isCheked: .constant(false))
+            CheckboxView(isChecked: .constant(true))
+            CheckboxView(isChecked: .constant(false))
         }
         .previewLayout(.fixed(width: 20, height: 20))
     }


### PR DESCRIPTION
Rename the misspelled `isCheked` property to `isChecked` in `CheckboxView` and all 4 call sites.

Files changed:
- `Packages/Modules/Sources/Library/Views/CheckboxView.swift`
- `Azkar/Sources/Scenes/Settings/App Icons View/AppIconPackListView.swift`
- `Azkar/Sources/Scenes/Settings/Fonts/FontsListItemView.swift`
- `Azkar/Sources/Scenes/Settings/Reminders/Sound Picker/ReminderSoundPickerView.swift`
- `Azkar/Sources/Scenes/Item Picker/ItemPickerView.swift`

Pure rename, no behavior change.