### PR TITLE
Combine duplicate .onAppear modifiers in ZikrView

### DIFF
--- a/Azkar/Sources/Scenes/Zikr View/ZikrView.swift
+++ b/Azkar/Sources/Scenes/Zikr View/ZikrView.swift
@@ -67,13 +67,11 @@ struct ZikrView: View {
         }
         .onAppear {
             AnalyticsReporter.reportScreen("Zikr Reading", className: viewName)
-        }
-        .environment(\.highlightPattern, viewModel.highlightPattern)
-        .onAppear {
             Task {
                 await viewModel.updateRemainingRepeats()
             }
         }
+        .environment(\.highlightPattern, viewModel.highlightPattern)
         .onDisappear(perform: viewModel.pausePlayer)
         .removeSaturationIfNeeded()
         .background(.background, ignoreSafeArea: .all)


### PR DESCRIPTION
## Change

Combined two separate `.onAppear` modifiers on the same `ScrollView` in `ZikrView.swift` into a single `.onAppear` callback.

## Reason

The two `.onAppear` blocks were redundant — SwiftUI calls all `.onAppear` callbacks when a view appears. Merging them into one is clearer and more idiomatic.

## Verification

Visual review of the modifier chain. No behavior change: analytics reporting and `updateRemainingRepeats()` still execute on appear in the same order.

## Risks

None — purely a readability improvement with identical runtime behavior.