### PR TITLE
Remove unused cancellabels property and Combine import

### DIFF
--- a/Azkar/Sources/Scenes/Settings/App Icons View/AppIconPackListView.swift
+++ b/Azkar/Sources/Scenes/Settings/App Icons View/AppIconPackListView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Combine
 import FactoryKit
 import Library
 
@@ -11,8 +10,6 @@ final class AppIconPackListViewModel: ObservableObject {
     @Published var icon: AppIcon = .gold
     
     let iconPacks: [AppIconPack] = AppIconPack.allCases
-
-    private var cancellabels = Set<AnyCancellable>()
 
     init(subscribeScreenTrigger: @escaping Action) {
         self.subscribeScreenTrigger = subscribeScreenTrigger


### PR DESCRIPTION
## Change

Remove unused `cancellabels` property and `Combine` import from `AppIconPackListViewModel`.

## Why

The property `cancellabels` was a typo (should be `cancellables`) that was declared but never used. The `Combine` import was only needed for that property.

- File: `Azkar/Sources/Scenes/Settings/App Icons View/AppIconPackListView.swift`
- Removed: `import Combine` (line 2)
- Removed: `private var cancellabels = Set<AnyCancellable>()` (line 15)