### PR TITLE
Replace deprecated @Environment(\.presentationMode) with @Environment(\.dismiss)

### DIFF
--- a/Azkar/Sources/Scenes/Item Picker/ItemPickerView.swift
+++ b/Azkar/Sources/Scenes/Item Picker/ItemPickerView.swift
@@ -3,7 +3,7 @@ import Library
 
 struct ItemPickerView<SelectionValue>: View where SelectionValue: Hashable & Identifiable & PickableItem {
 
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
     @Binding var selection: SelectionValue
     var header: String?
     let items: [SelectionValue]
@@ -45,7 +45,7 @@ struct ItemPickerView<SelectionValue>: View where SelectionValue: Hashable & Ide
                     }
                     UISelectionFeedbackGenerator().selectionChanged()
                     if self.dismissOnSelect {
-                        self.presentationMode.wrappedValue.dismiss()
+                        self.dismiss()
                     }
                 }
             } label: {

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Sections.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Sections.swift
@@ -9,7 +9,7 @@ extension ZikrShareOptionsView {
     var toolbar: some View {
         HStack(spacing: 16) {
             Button(LocalizedStringKey("common.done")) {
-                presentation.dismiss()
+                dismiss()
             }
             Spacer()
 

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView.swift
@@ -89,7 +89,7 @@ struct ZikrShareOptionsView: View {
     let callback: (ShareOptions) -> Void
 
     @EnvironmentObject var backgroundsService: ShareBackgroundsServiceType
-    @Environment(\.presentationMode) var presentation
+    @Environment(\.dismiss) var dismiss
     @Environment(\.appTheme) var appTheme
     @Environment(\.colorTheme) var colorTheme
     @Injected(\.subscriptionManager) var subscriptionManager: SubscriptionManagerType
@@ -217,7 +217,7 @@ struct ZikrShareOptionsView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(LocalizedStringKey("common.done")) {
-                        presentation.dismiss()
+                        dismiss()
                     }
                 }
                 


### PR DESCRIPTION
## Summary

- Replaces `@Environment(\.presentationMode)` with `@Environment(\.dismiss)` in 2 files (3 usages)
- `presentationMode` was deprecated in iOS 15; the project's deployment target is iOS 15.0
- `ZikrCollectionsOnboardingFlowView` already uses the modern `@Environment(\.dismiss)` pattern

## Files changed

- `ItemPickerView.swift`: declare `@Environment(\.dismiss) var dismiss`, call `dismiss()`
- `ZikrShareOptionsView.swift`: same migration
- `ZikrShareOptionsView+Sections.swift`: update call site to match new property name

No logic changes — pure API migration.