### PR TITLE
Remove force unwrap of URL in FeedbackMailPresenter

### DIFF
--- a/Azkar/Sources/Services/FeedbackMailPresenter.swift
+++ b/Azkar/Sources/Services/FeedbackMailPresenter.swift
@@ -7,7 +7,8 @@ final class FeedbackMailPresenter {
 
     func present(from viewController: UIViewController) {
         guard MFMailComposeViewController.canSendMail() else {
-            UIApplication.shared.open(URL(string: "https://t.me/jawziyya_feedback")!)
+            guard let url = URL(string: "https://t.me/jawziyya_feedback") else { return }
+            UIApplication.shared.open(url)
             return
         }
 


### PR DESCRIPTION
Replaces  with a  for defensive safety, following the same pattern used in other merged PRs that removed force unwraps from the codebase (e.g., #123, #143).

The hardcoded URL string is unlikely to be malformed at runtime, but the guard-let form is more resilient and consistent with project conventions.