### PR TITLE
Remove force unwrap of UIImage in ZikrShareBackgroundItem

### DIFF
--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareBackgroundItem.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareBackgroundItem.swift
@@ -40,10 +40,13 @@ extension ZikrShareBackgroundItem {
     ]
     
     static var images: [ZikrShareBackgroundItem] {
-        imageNames.map {
-            ZikrShareBackgroundItem(
+        imageNames.compactMap {
+            guard let image = UIImage(named: "Patterns/" + $0.imageName, in: resourcesBundle, with: nil) else {
+                return nil
+            }
+            return ZikrShareBackgroundItem(
                 id: $0.imageName,
-                background: .localImage(UIImage(named: "Patterns/" + $0.imageName, in: resourcesBundle, with: nil)!),
+                background: .localImage(image),
                 type: $0.type,
                 isProItem: false
             )


### PR DESCRIPTION
Replaces `.map` with force-unwrap on `UIImage(named:in:with:)` with `.compactMap` and a `guard let`, so missing image assets are silently skipped instead of crashing the share feature.

This prevents a crash if any of the share background pattern images are renamed, deleted, or missing from the bundle.

**Changed file:** `Azkar/Sources/Scenes/Zikr Share View/ZikrShareBackgroundItem.swift`

**Verification:** Project builds successfully with `xcodebuild`.