### PR TITLE
Remove force unwrap of UIImage in ArticleScreen sharedWithAzkarView

### DIFF
--- a/Packages/Modules/Sources/ArticleReader/ArticleScreen.swift
+++ b/Packages/Modules/Sources/ArticleReader/ArticleScreen.swift
@@ -85,10 +85,12 @@ public struct ArticleScreen: View {
     
     var sharedWithAzkarView: some View {
         VStack {
-            Image(uiImage: UIImage(named: "ink", in: azkarResourcesBundle, compatibleWith: nil)!)
-                .resizable()
-                .frame(width: 30, height: 30)
-                .cornerRadius(6)
+            if let image = UIImage(named: "ink", in: azkarResourcesBundle, compatibleWith: nil) {
+                Image(uiImage: image)
+                    .resizable()
+                    .frame(width: 30, height: 30)
+                    .cornerRadius(6)
+            }
             Text("share.shared-with-azkar")
                 .foregroundStyle(Color.secondary)
                 .systemFont(12, modification: .smallCaps)


### PR DESCRIPTION
Replaces the force unwrap of `UIImage(named:in:compatibleWith:)` in the `sharedWithAzkarView` with a safe `if let` binding. If the image resource is missing, the view gracefully omits the image instead of crashing.

Follows the same pattern as [JAW-100](/PAP/issues/PAP-100) (ZikrShareBackgroundItem).