### PR TITLE
Remove unused clearAllMenu function from SearchSuggestionsView

### DIFF
--- a/Azkar/Sources/Scenes/SearchSuggestions/SearchSuggestionsView.swift
+++ b/Azkar/Sources/Scenes/SearchSuggestions/SearchSuggestionsView.swift
@@ -104,19 +104,6 @@ struct SearchSuggestionsView: View {
             .padding(.top, 6)
     }
     
-    func clearAllMenu(action: @escaping () -> Void) -> some View {
-        Menu {
-            Text("Please confirm this action")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Button(role: .destructive, action: action) {
-                Label("Clear", systemImage: "trash")
-            }
-        } label: {
-            Text("Clear All")
-        }
-    }
-    
 }
 
 #Preview("Search Suggestions") {


### PR DESCRIPTION
## Summary

- Removed the unused `clearAllMenu` function from `SearchSuggestionsView.swift`
- The function was never called anywhere in the codebase
- It contained hardcoded English strings ("Please confirm this action", "Clear", "Clear All") instead of localized string keys

## Verification

- Searched the entire codebase for `clearAllMenu` — confirmed zero usages outside its own definition
- Change is a pure deletion of dead code, no behavior change