### PR TITLE
Remove unused adhkarSourcePicker and contentLanguagePicker from TextSettingsScreen

### DIFF
--- a/Azkar/Sources/Scenes/Settings/Text/TextSettingsScreen.swift
+++ b/Azkar/Sources/Scenes/Settings/Text/TextSettingsScreen.swift
@@ -142,21 +142,6 @@ struct TextSettingsScreen: View {
         FontsView(viewModel: viewModel.getFontsViewModel(fontsType: .translation))
     }
     
-    var adhkarSourcePicker: some View {
-        ItemPickerView(
-            selection: $viewModel.preferences.zikrCollectionSource,
-            items: ZikrCollectionSource.allCases,
-            dismissOnSelect: true
-        )
-    }
-    
-    var contentLanguagePicker: some View {
-        ItemPickerView(
-            selection: $viewModel.preferences.contentLanguage,
-            items: viewModel.getAvailableLanguages(),
-            dismissOnSelect: true
-        )
-    }
 }
 
 #Preview {


### PR DESCRIPTION
Removes two unused computed properties from TextSettingsScreen:

- `adhkarSourcePicker` (lines 145–151)
- `contentLanguagePicker` (lines 153–159)

Both were defined but never referenced in the view body. The view uses inline picker logic in the `collectionSection` and `textContentSettings` computed properties instead.