### PR TITLE
Remove unused cancellables property from SearchManager

### DIFF
--- a/Azkar/Sources/Scenes/Search Results/SearchManager.swift
+++ b/Azkar/Sources/Scenes/Search Results/SearchManager.swift
@@ -13,8 +13,6 @@ final class SearchManager {
 
     private var searchTask: Task<Void, Never>?
     private let searchResultSectionsPublisher = PassthroughSubject<SearchResultsSection, Never>()
-    private var cancellables = Set<AnyCancellable>()
-    
     private let languages: [Language]
     private let azkarDatabase: AzkarDatabase
 


### PR DESCRIPTION
The `cancellables` property on line 16 of `SearchManager.swift` was declared but never used. The file uses `Task`-based concurrency and `PassthroughSubject` — no Combine subscriptions use `.store(in: &cancellables)`.

`import Combine` is still needed for `PassthroughSubject` and `AnyPublisher`.

Follows the same pattern as [JAW-95](https://github.com/Jawziyya/azkar-ios/pull/147).