### PR TITLE
Remove force unwrap of URL in FontsService.loadFonts

### DIFF
--- a/Azkar/Sources/Scenes/Settings/Fonts/FontsService/FontsService.swift
+++ b/Azkar/Sources/Scenes/Settings/Fonts/FontsService/FontsService.swift
@@ -9,7 +9,7 @@ import Extensions
 struct FontsService: FontsServiceType {
     
     func loadFonts<T>(of type: FontsType) async throws -> [T] where T : AppFont, T : Decodable {
-        let fontsListURL = URL(string: type.url)!
+        let fontsListURL = type.url
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         return try await AF.request(

--- a/Packages/Modules/Sources/Library/Fonts/FontsService/FontsServiceType.swift
+++ b/Packages/Modules/Sources/Library/Fonts/FontsService/FontsServiceType.swift
@@ -5,12 +5,12 @@ import Foundation
 public enum FontsType {
     case arabic, translation
     
-    public var url: String {
+    public var url: URL {
         switch self {
         case .arabic:
-            return "https://storage.yandexcloud.net/azkar/fonts/arabic_fonts.json"
+            return URL(string: "https://storage.yandexcloud.net/azkar/fonts/arabic_fonts.json")!
         case .translation:
-            return "https://storage.yandexcloud.net/azkar/fonts/translation_fonts.json"
+            return URL(string: "https://storage.yandexcloud.net/azkar/fonts/translation_fonts.json")!
         }
     }
 }


### PR DESCRIPTION
Moves the `URL(string:)` conversion from `FontsService.loadFonts` into `FontsType.url`, changing the property from `String` to `URL`.

The force unwrap now lives in `FontsType` where the URL strings are known-good compile-time constants, so `FontsService` no longer has a crash risk if the API is ever extended with an invalid URL string.

**Files changed:**
- `FontsServiceType.swift`: `url` now returns `URL` instead of `String`
- `FontsService.swift`: uses `type.url` directly instead of `URL(string: type.url)!`