### PR TITLE
Add accessibility label to info button in FontsView

### DIFF
--- a/Azkar/Sources/Scenes/Settings/Fonts/FontsView.swift
+++ b/Azkar/Sources/Scenes/Settings/Fonts/FontsView.swift
@@ -78,6 +78,7 @@ struct FontsView: View {
                     } label: { _ in
                         Image(systemName: "info")
                             .foregroundStyle(.accent)
+                            .accessibilityLabel(Text("accessibility.common.more-info"))
                     }
                 }
             }


### PR DESCRIPTION
Other info buttons across the app (TextSettingsScreen, ExtraTextSettingsScreen, AppearanceScreen, CounterScreen) already have `.accessibilityLabel(Text("accessibility.common.more-info"))` for VoiceOver support. FontsView's arabic fonts info button was the only one missing it.

- **File:** `Azkar/Sources/Scenes/Settings/Fonts/FontsView.swift:81`
- **Change:** Added `.accessibilityLabel(Text("accessibility.common.more-info"))` to the `Image(systemName: "info")` in the toolbar menu label
- **Risk:** None — purely additive accessibility improvement