### PR TITLE
Replace deprecated BorderlessButtonStyle() with .plain

### DIFF
--- a/Azkar/Sources/Library/Custom Views/CollapsableSection.swift
+++ b/Azkar/Sources/Library/Custom Views/CollapsableSection.swift
@@ -43,7 +43,7 @@ struct CollapsableSection: View, Equatable {
                     isExpandable: expandingCallback != nil
                 )
             })
-            .buttonStyle(BorderlessButtonStyle())
+            .buttonStyle(.plain)
             .zIndex(1)
 
             ZStack {

--- a/Azkar/Sources/Library/Custom Views/CollapsableView.swift
+++ b/Azkar/Sources/Library/Custom Views/CollapsableView.swift
@@ -14,7 +14,7 @@ struct CollapsableView<Header: View, Content: View>: View {
             }, label: {
                 header()
             })
-            .buttonStyle(BorderlessButtonStyle())
+            .buttonStyle(.plain)
             .zIndex(1)
 
             ZStack {


### PR DESCRIPTION
## Summary

- Replaces `BorderlessButtonStyle()` with the modern `.plain` shorthand in two files
- Aligns with the rest of the codebase which consistently uses `.buttonStyle(.plain)`
- No behavior change — both styles are functionally equivalent