### PR TITLE
Remove unused String.nsRange property with force unwrap

### DIFF
--- a/Packages/Core/Sources/Extensions/String.swift
+++ b/Packages/Core/Sources/Extensions/String.swift
@@ -21,10 +21,6 @@ extension String: @retroactive Identifiable {
 
 public extension String {
 
-    var nsRange: NSRange {
-      return NSRange(range(of: self)!, in: self)
-    }
-
     var textOrNil: String? {
         let text = trimmingCharacters(in: .whitespacesAndNewlines)
         return text.isEmpty ? nil : text


### PR DESCRIPTION
The  property on  was defined but never used anywhere in the codebase. It contained an unnecessary force unwrap () that would crash on an empty string.

Removing dead code with an unsafe pattern.

- **Verified:** Builds successfully ( for Azkar scheme, generic iOS Simulator)
- **Risk:** None — property was unused, no callers affected