### PR TITLE
Replace deprecated .navigationBarTitle with .navigationTitle

### DIFF
--- a/Azkar/Sources/RootView.swift
+++ b/Azkar/Sources/RootView.swift
@@ -44,7 +44,7 @@ struct RootView: View {
             viewModel: viewModel.mainMenuViewModel
         )
         .environmentObject(ZikrCounter.shared)
-        .navigationBarTitle(appName)
+        .navigationTitle(appName)
         .navigationTitleMode(.large)
         .searchable(
             text: $viewModel.mainMenuViewModel.searchQuery,

--- a/Azkar/Sources/Scenes/Settings/Text/ExtraTextSettingsScreen.swift
+++ b/Azkar/Sources/Scenes/Settings/Text/ExtraTextSettingsScreen.swift
@@ -125,7 +125,7 @@ struct ExtraTextSettingsScreen: View {
                 .listRowBackground(colorTheme.getColor(.contentBackground))
             }
             .customScrollContentBackground()
-            .navigationBarTitle("settings.text.line-spacing")
+            .navigationTitle("settings.text.line-spacing")
             .background(.background, ignoreSafeArea: .all)
         } label: {
             NavigationLabel(title: "settings.text.line-spacing")

--- a/Packages/Modules/Sources/AboutApp/CreditsScreen.swift
+++ b/Packages/Modules/Sources/AboutApp/CreditsScreen.swift
@@ -27,7 +27,7 @@ public struct CreditsScreen: View {
         .customScrollContentBackground()
         .background(.background, ignoreSafeArea: .all)
         .listStyle(.grouped)
-        .navigationBarTitle("credits.title")
+        .navigationTitle("credits.title")
         .removeSaturationIfNeeded()
     }
     


### PR DESCRIPTION
## Summary

- Replaces 3 instances of deprecated `.navigationBarTitle(String)` (without `displayMode:`) with `.navigationTitle(String)`
- Updated files: `RootView.swift`, `ExtraTextSettingsScreen.swift`, `CreditsScreen.swift`

## Why

`.navigationBarTitle(String)` without `displayMode:` was deprecated in favor of `.navigationTitle(String)`. This is a straightforward 1:1 replacement with identical behavior.