### PR TITLE
Fix typo: supportsCyryllicCharacters -> supportsCyrillicCharacters

### DIFF
--- a/Azkar/Sources/Scenes/Settings/Fonts/FontsListItemViewModel.swift
+++ b/Azkar/Sources/Scenes/Settings/Fonts/FontsListItemViewModel.swift
@@ -36,7 +36,7 @@ struct AppFontViewModel: Identifiable, Equatable, Hashable {
             langIdSuffix = ""
             supportsTashkeel = arabicFont.hasTashkeelSupport
         } else if let translationFont = font as? TranslationFont {
-            supportsCyrillicCharacters = translationFont.supportsCyryllicCharacters
+            supportsCyrillicCharacters = translationFont.supportsCyrillicCharacters
             switch language {
             case .arabic: langIdSuffix = "_en"
             default: langIdSuffix = "_" + language.id

--- a/Azkar/Sources/Scenes/Settings/Fonts/FontsViewModel.swift
+++ b/Azkar/Sources/Scenes/Settings/Fonts/FontsViewModel.swift
@@ -175,7 +175,7 @@ final class FontsViewModel: ObservableObject {
                     let fontViewModels = fonts
                         .filter { font in
                             if !isArabicFonts && !showNonCyrillicFonts, let translationFont = font as? TranslationFont {
-                                return translationFont.supportsCyryllicCharacters
+                                return translationFont.supportsCyrillicCharacters
                             }
                             return true
                         }

--- a/Packages/Modules/Sources/Library/Fonts/TranslationFont.swift
+++ b/Packages/Modules/Sources/Library/Fonts/TranslationFont.swift
@@ -29,7 +29,7 @@ public struct TranslationFont: Codable, Identifiable, Hashable, AppFont {
     public var sizeAdjustment: Float?
     public var lineAdjustment: Float?
     
-    public var supportsCyryllicCharacters: Bool {
+    public var supportsCyrillicCharacters: Bool {
         isCyrillic == 1
     }
     


### PR DESCRIPTION
The `TranslationFont.supportsCyryllicCharacters` property had a misspelling — "Cyryllic" (double L) instead of "Cyrillic". Renamed the public property and updated all call sites.

## Files changed
- `Packages/Modules/Sources/Library/Fonts/TranslationFont.swift` — property definition
- `Azkar/Sources/Scenes/Settings/Fonts/FontsListItemViewModel.swift` — usage site
- `Azkar/Sources/Scenes/Settings/Fonts/FontsViewModel.swift` — usage site

## Verification
- Grepped codebase to confirm no remaining references to old spelling
- All 3 call sites updated consistently