### PR TITLE
Replace deprecated .navigationBarTitle(_:displayMode:) in PickerView

### DIFF
--- a/Azkar/Sources/Library/Custom Views/PickerView.swift
+++ b/Azkar/Sources/Library/Custom Views/PickerView.swift
@@ -10,7 +10,7 @@ struct PickerView<T: View>: View {
 
     var body: some View {
         NavigationLink(
-            destination: destination.navigationBarTitle(navigationTitle ?? label, displayMode: titleDisplayMode)
+            destination: destination.navigationTitle(navigationTitle ?? label).navigationBarTitleDisplayMode(titleDisplayMode)
         ) {
             NavigationLabel(title: label, label: subtitle)
         }


### PR DESCRIPTION
## Change

Replaces the deprecated `.navigationBarTitle(_:displayMode:)` call in `PickerView.swift` with the two non-deprecated replacements: `.navigationTitle(_:)` and `.navigationBarTitleDisplayMode(_:)`.

## Context

Open PR [JAW-111](https://github.com/Jawziyya/azkar-ios/pull/162) covers this same deprecation for `RootView.swift`, `ExtraTextSettingsScreen.swift`, and `CreditsScreen.swift`, but missed `PickerView.swift` which uses the more complex form with an explicit `displayMode:` parameter.