### PR TITLE
Remove force unwraps of Bundle info dictionary in SettingsFlowView

### DIFF
--- a/Azkar/Sources/Scenes/Settings/SettingsFlowView.swift
+++ b/Azkar/Sources/Scenes/Settings/SettingsFlowView.swift
@@ -201,8 +201,8 @@ private struct AboutAppDestinationView: View {
         AppInfoView(
             viewModel: AppInfoViewModel(
                 appVersion: {
-                    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")!
-                    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion")!
+                    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? "?"
+                    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") ?? "?"
                     return "\(String(localized: "common.version")) \(version) (\(build))"
                 }(),
                 isProUser: subscriptionManager.isProUser()


### PR DESCRIPTION
Replaces force unwraps of `Bundle.main.object(forInfoDictionaryKey:)` with nil-coalescing fallback values in `AboutAppDestinationView`, matching the pattern from prior PRs (JAW-97, JAW-105).