### PR TITLE
Replace deprecated PlainButtonStyle() with .plain

### DIFF
--- a/Azkar/Sources/Scenes/Azkar List/AzkarListView.swift
+++ b/Azkar/Sources/Scenes/Azkar List/AzkarListView.swift
@@ -58,7 +58,7 @@ struct AzkarListView: View {
             .padding()
             .contentShape(Rectangle())
         }
-        .buttonStyle(PlainButtonStyle())
+        .buttonStyle(.plain)
         .accessibilityLabel(title)
         .applyAccessibilityLanguage(zikr.zikr.language.id)
     }

--- a/Azkar/Sources/Scenes/Settings/Reminders/NotificationsDisabledView.swift
+++ b/Azkar/Sources/Scenes/Settings/Reminders/NotificationsDisabledView.swift
@@ -104,7 +104,7 @@ struct NotificationsDisabledView: View {
                     .multilineTextAlignment(.leading)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.plain)
         }
         .padding(.vertical, 8)
     }

--- a/Packages/Modules/Sources/AboutApp/CreditsScreen.swift
+++ b/Packages/Modules/Sources/AboutApp/CreditsScreen.swift
@@ -51,7 +51,7 @@ public struct CreditsScreen: View {
             .background(.contentBackground)
             .clipShape(Rectangle())
         })
-        .buttonStyle(PlainButtonStyle())
+        .buttonStyle(.plain)
         .padding(.vertical, 8)
         .padding(.horizontal, 12)
     }

--- a/Packages/Modules/Sources/Library/SwiftUI/RectangularToggleStyle.swift
+++ b/Packages/Modules/Sources/Library/SwiftUI/RectangularToggleStyle.swift
@@ -34,7 +34,7 @@ public struct RectangularToggleStyle: ToggleStyle {
                 }
                 .animation(.smooth, value: configuration.isOn)
             }
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.plain)
         }
         .hapticFeedback(.impact(flexibility: .soft), trigger: configuration.isOn)
     }


### PR DESCRIPTION
Follow-up to [#160](https://github.com/jawziyya/azkar-ios/pull/160) which migrated `BorderlessButtonStyle()` to `.plain`. The codebase already uses `.buttonStyle(.plain)` in 21 places; these were the last 4 remaining `PlainButtonStyle()` explicit initializers.

**Files changed:**
- `CreditsScreen.swift`
- `NotificationsDisabledView.swift`
- `AzkarListView.swift`
- `RectangularToggleStyle.swift`