### PR TITLE
Fix typo: occured -> occurred in AudioPlayer doc comments

### DIFF
--- a/Packages/Modules/Sources/AudioPlayer/event/AudioItemEventProducer.swift
+++ b/Packages/Modules/Sources/AudioPlayer/event/AudioItemEventProducer.swift
@@ -48,7 +48,7 @@ class AudioItemEventProducer: NSObject, EventProducer {
         }
     }
 
-    /// The listener that will be alerted a new event occured.
+    /// The listener that will be alerted a new event occurred.
     weak var eventListener: EventListener?
 
     /// A boolean value indicating whether we're currently listening to events on the player.

--- a/Packages/Modules/Sources/AudioPlayer/event/EventProducer.swift
+++ b/Packages/Modules/Sources/AudioPlayer/event/EventProducer.swift
@@ -16,14 +16,14 @@ protocol EventListener: AnyObject {
     /// Called when an event occurs.
     ///
     /// - Parameters:
-    ///   - event: The event that occured.
+    ///   - event: The event that occurred.
     ///   - eventProducer: The producer at the root of the event.
     func onEvent(_ event: Event, generetedBy eventProducer: EventProducer)
 }
 
 /// An `EventProducer` serves the purpose of producing events over time.
 protocol EventProducer: AnyObject {
-    /// The listener that will be alerted a new event occured.
+    /// The listener that will be alerted a new event occurred.
     var eventListener: EventListener? { get set }
 
     /// Tells the producer to start producing events.

--- a/Packages/Modules/Sources/AudioPlayer/event/NetworkEventProducer.swift
+++ b/Packages/Modules/Sources/AudioPlayer/event/NetworkEventProducer.swift
@@ -33,7 +33,7 @@ class NetworkEventProducer: NSObject, EventProducer {
     /// The date at which connection was lost.
     private(set) var connectionLossDate: NSDate?
 
-    /// The listener that will be alerted a new event occured.
+    /// The listener that will be alerted a new event occurred.
     weak var eventListener: EventListener?
 
     /// A boolean value indicating whether we're currently listening to events on the player.

--- a/Packages/Modules/Sources/AudioPlayer/event/PlayerEventProducer.swift
+++ b/Packages/Modules/Sources/AudioPlayer/event/PlayerEventProducer.swift
@@ -85,7 +85,7 @@ class PlayerEventProducer: NSObject, EventProducer {
         }
     }
 
-    /// The listener that will be alerted a new event occured.
+    /// The listener that will be alerted a new event occurred.
     weak var eventListener: EventListener?
 
     /// The time observer for the player.

--- a/Packages/Modules/Sources/AudioPlayer/event/QualityAdjustmentEventProducer.swift
+++ b/Packages/Modules/Sources/AudioPlayer/event/QualityAdjustmentEventProducer.swift
@@ -28,7 +28,7 @@ class QualityAdjustmentEventProducer: NSObject, EventProducer {
     /// The timer used to adjust quality
     private var timer: Timer?
 
-    /// The listener that will be alerted a new event occured.
+    /// The listener that will be alerted a new event occurred.
     weak var eventListener: EventListener?
 
     /// A boolean value indicating whether we're currently producing events or not.

--- a/Packages/Modules/Sources/AudioPlayer/event/RetryEventProducer.swift
+++ b/Packages/Modules/Sources/AudioPlayer/event/RetryEventProducer.swift
@@ -28,7 +28,7 @@ class RetryEventProducer: NSObject, EventProducer {
     /// The timer used to adjust quality
     private var timer: Timer?
 
-    /// The listener that will be alerted a new event occured.
+    /// The listener that will be alerted a new event occurred.
     weak var eventListener: EventListener?
 
     /// A boolean value indicating whether we're currently producing events or not.

--- a/Packages/Modules/Sources/AudioPlayer/event/SeekEventProducer.swift
+++ b/Packages/Modules/Sources/AudioPlayer/event/SeekEventProducer.swift
@@ -27,7 +27,7 @@ class SeekEventProducer: NSObject, EventProducer {
     /// The timer used to generate events.
     private var timer: Timer?
 
-    /// The listener that will be alerted a new event occured.
+    /// The listener that will be alerted a new event occurred.
     weak var eventListener: EventListener?
 
     /// A boolean value indicating whether we're currently producing events or not.

--- a/Packages/Modules/Sources/AudioPlayer/player/AudioPlayerState.swift
+++ b/Packages/Modules/Sources/AudioPlayer/player/AudioPlayerState.swift
@@ -28,7 +28,7 @@ public enum AudioPlayerError: Error {
 /// - paused: The player is paused.
 /// - stopped: The player is stopped.
 /// - waitingForConnection: The player is waiting for internet connection.
-/// - failed: An error occured. It contains AVPlayer's error if any.
+/// - failed: An error occurred. It contains AVPlayer's error if any.
 public enum AudioPlayerState {
     case buffering
     case playing


### PR DESCRIPTION
## Summary

- Fix misspelling `occured` → `occurred` in 9 doc comments across 8 files in the AudioPlayer module
- All changes are comment-only; no functional or API changes

## Files changed

- `EventProducer.swift` (2 instances)
- `RetryEventProducer.swift`
- `SeekEventProducer.swift`
- `QualityAdjustmentEventProducer.swift`
- `PlayerEventProducer.swift`
- `NetworkEventProducer.swift`
- `AudioItemEventProducer.swift`
- `AudioPlayerState.swift`