### PR TITLE
Remove unused import Popovers from SettingsView and ZikrShareOptionsView

### DIFF
--- a/Azkar/Sources/Scenes/Settings/SettingsView.swift
+++ b/Azkar/Sources/Scenes/Settings/SettingsView.swift
@@ -1,7 +1,6 @@
 //  Copyright © 2020 Al Jawziyya. All rights reserved.
 
 import SwiftUI
-import Popovers
 import Entities
 import Library
 import Components

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 import AudioPlayer
 import FactoryKit
 import Library
-import Popovers
 import Entities
 import AzkarResources
 import Extensions


### PR DESCRIPTION
Both files import the Popovers module but never reference any of its APIs (Templates, .popover, etc.). Removing the unused import cleans up the dependency graph and speeds up compilation slightly.