### PR TITLE
[codex] Add local usage analytics

### DIFF
--- a/Azkar/Sources/AzkarApp.swift
+++ b/Azkar/Sources/AzkarApp.swift
@@ -62,17 +62,17 @@ struct AzkarApp: App {
                 case .evening: category = .evening
                 case .jumua: category = .hundredDua
                 }
-                localAnalytics.track(.appEntrypointUsed(
-                    source: "notification",
-                    target: category.rawValue
-                ))
+                localAnalytics.entrypoint.used(
+                    source: .notification,
+                    target: .category(category)
+                )
                 self.deepLinker.open(.azkar(category))
             }
             .onReceive(quickActionDispatcher.routes) { route in
-                localAnalytics.track(.appEntrypointUsed(
-                    source: "quick_action",
+                localAnalytics.entrypoint.used(
+                    source: .quickAction,
                     target: route.analyticsTarget
-                ))
+                )
                 deepLinker.open(route)
             }
             .onOpenURL { url in
@@ -96,10 +96,10 @@ struct AzkarApp: App {
             return
         }
         defaults?.removeObject(forKey: "controlCenterDeepLink")
-        localAnalytics.track(.appEntrypointUsed(
-            source: "control_center",
-            target: url.host ?? "unknown"
-        ))
+        localAnalytics.entrypoint.used(
+            source: .controlCenter,
+            target: .raw(url.host ?? "unknown")
+        )
         handleIncomingURL(url)
     }
 
@@ -107,10 +107,10 @@ struct AzkarApp: App {
         guard let route = quickActionDispatcher.takePendingRoute() else {
             return
         }
-        localAnalytics.track(.appEntrypointUsed(
-            source: "quick_action",
+        localAnalytics.entrypoint.used(
+            source: .quickAction,
             target: route.analyticsTarget
-        ))
+        )
         deepLinker.open(route)
     }
 
@@ -118,10 +118,10 @@ struct AzkarApp: App {
         guard let deepLink = AppDeepLink(url: url) else {
             return
         }
-        localAnalytics.track(.appEntrypointUsed(
-            source: "deeplink",
+        localAnalytics.entrypoint.used(
+            source: .deeplink,
             target: deepLink.analyticsTarget
-        ))
+        )
         deepLinker.open(deepLink.route)
     }
 
@@ -132,10 +132,10 @@ struct AzkarApp: App {
         else {
             return
         }
-        localAnalytics.track(.appEntrypointUsed(
-            source: "spotlight",
+        localAnalytics.entrypoint.used(
+            source: .spotlight,
             target: deepLink.analyticsTarget
-        ))
+        )
         deepLinker.open(deepLink.route)
     }
     
@@ -283,20 +283,20 @@ struct AzkarApp: App {
 
 private extension AppDeepLink {
 
-    var analyticsTarget: String {
+    var analyticsTarget: AppAnalyticsEntrypointTarget {
         switch self {
         case .home:
-            return "home"
+            return .home
         case .category(let category):
-            return "category_\(category.rawValue)"
+            return .category(category)
         case .categoryZikr(let category, _):
-            return "category_zikr_\(category.rawValue)"
+            return .categoryZikr(category)
         case .zikr:
-            return "zikr"
+            return .zikr
         case .article:
-            return "article"
+            return .article
         case .hadith:
-            return "hadith"
+            return .hadith
         }
     }
 
@@ -304,22 +304,22 @@ private extension AppDeepLink {
 
 private extension Deeplinker.Route {
 
-    var analyticsTarget: String {
+    var analyticsTarget: AppAnalyticsEntrypointTarget {
         switch self {
         case .home:
-            return "home"
+            return .home
         case .settings:
-            return "settings"
+            return .settings
         case .azkar(let category):
-            return "category_\(category.rawValue)"
+            return .category(category)
         case .categoryZikr(let category, _):
-            return "category_zikr_\(category.rawValue)"
+            return .categoryZikr(category)
         case .zikr:
-            return "zikr"
+            return .zikr
         case .article:
-            return "article"
+            return .article
         case .hadith:
-            return "hadith"
+            return .hadith
         }
     }
 

--- a/Azkar/Sources/AzkarApp.swift
+++ b/Azkar/Sources/AzkarApp.swift
@@ -21,6 +21,7 @@ struct AzkarApp: App {
     @Injected(\.deeplinker) private var deepLinker: Deeplinker
     @Injected(\.quickActionDispatcher) private var quickActionDispatcher: QuickActionDispatcher
     @Injected(\.subscriptionManager) private var subscriptionManager: SubscriptionManagerType
+    @Injected(\.localAnalytics) private var localAnalytics: AppAnalyticsTracking
 
     init() {
         setNavigationBarFont(theme: preferences.appTheme, colorTheme: preferences.colorTheme)
@@ -30,7 +31,10 @@ struct AzkarApp: App {
     var body: some Scene {
         WindowGroup {
             AppFlowView()
-            .task { await presentPaywall() }
+            .task {
+                localAnalytics.start()
+                await presentPaywall()
+            }
             .connectAppTheme()
             .connectCustomFonts()
             .attachEnvironmentOverrides(onChange: { _ in
@@ -58,9 +62,17 @@ struct AzkarApp: App {
                 case .evening: category = .evening
                 case .jumua: category = .hundredDua
                 }
+                localAnalytics.track(.appEntrypointUsed(
+                    source: "notification",
+                    target: category.rawValue
+                ))
                 self.deepLinker.open(.azkar(category))
             }
             .onReceive(quickActionDispatcher.routes) { route in
+                localAnalytics.track(.appEntrypointUsed(
+                    source: "quick_action",
+                    target: route.analyticsTarget
+                ))
                 deepLinker.open(route)
             }
             .onOpenURL { url in
@@ -84,6 +96,10 @@ struct AzkarApp: App {
             return
         }
         defaults?.removeObject(forKey: "controlCenterDeepLink")
+        localAnalytics.track(.appEntrypointUsed(
+            source: "control_center",
+            target: url.host ?? "unknown"
+        ))
         handleIncomingURL(url)
     }
 
@@ -91,6 +107,10 @@ struct AzkarApp: App {
         guard let route = quickActionDispatcher.takePendingRoute() else {
             return
         }
+        localAnalytics.track(.appEntrypointUsed(
+            source: "quick_action",
+            target: route.analyticsTarget
+        ))
         deepLinker.open(route)
     }
 
@@ -98,6 +118,10 @@ struct AzkarApp: App {
         guard let deepLink = AppDeepLink(url: url) else {
             return
         }
+        localAnalytics.track(.appEntrypointUsed(
+            source: "deeplink",
+            target: deepLink.analyticsTarget
+        ))
         deepLinker.open(deepLink.route)
     }
 
@@ -108,6 +132,10 @@ struct AzkarApp: App {
         else {
             return
         }
+        localAnalytics.track(.appEntrypointUsed(
+            source: "spotlight",
+            target: deepLink.analyticsTarget
+        ))
         deepLinker.open(deepLink.route)
     }
     
@@ -251,6 +279,50 @@ struct AzkarApp: App {
         )
     }
     
+}
+
+private extension AppDeepLink {
+
+    var analyticsTarget: String {
+        switch self {
+        case .home:
+            return "home"
+        case .category(let category):
+            return "category_\(category.rawValue)"
+        case .categoryZikr(let category, _):
+            return "category_zikr_\(category.rawValue)"
+        case .zikr:
+            return "zikr"
+        case .article:
+            return "article"
+        case .hadith:
+            return "hadith"
+        }
+    }
+
+}
+
+private extension Deeplinker.Route {
+
+    var analyticsTarget: String {
+        switch self {
+        case .home:
+            return "home"
+        case .settings:
+            return "settings"
+        case .azkar(let category):
+            return "category_\(category.rawValue)"
+        case .categoryZikr(let category, _):
+            return "category_zikr_\(category.rawValue)"
+        case .zikr:
+            return "zikr"
+        case .article:
+            return "article"
+        case .hadith:
+            return "hadith"
+        }
+    }
+
 }
 
 // Extension to get all child view controllers recursively

--- a/Azkar/Sources/Library/Keys.swift
+++ b/Azkar/Sources/Library/Keys.swift
@@ -34,6 +34,7 @@ enum Keys {
     static let contentLanguage = "kContentLanguage"
     static let spotlightIndexVersion = "kSpotlightIndexVersion"
     static let hasCompletedFirstLaunch = "kHasCompletedFirstLaunch"
+    static let firstOpenDate = "kFirstOpenDate"
     
     // MARK: Reminders
     static let enableReminders = "kEnableNotifications"

--- a/Azkar/Sources/Navigation/AppContainer.swift
+++ b/Azkar/Sources/Navigation/AppContainer.swift
@@ -45,11 +45,29 @@ extension Container {
             .singleton
     }
 
+    var appAnalyticsStack: Factory<AppAnalyticsStack> {
+        self {
+            AppAnalyticsStack(
+                preferences: self.preferences(),
+                notificationsHandler: self.notificationsHandler()
+            )
+        }
+        .singleton
+    }
+
+    var localAnalytics: Factory<AppAnalyticsTracking> {
+        self { self.appAnalyticsStack().localAnalytics }
+            .singleton
+    }
+
     var appDependencies: Factory<AppDependencies> {
         self {
+            let analyticsStack = self.appAnalyticsStack()
             AppDependencies(
                 preferences: self.preferences(),
-                player: self.player()
+                player: self.player(),
+                analytics: analyticsStack.localAnalytics,
+                analyticsDatabase: analyticsStack.processedEventsStore
             )
         }
         .singleton
@@ -59,7 +77,8 @@ extension Container {
         self { MainActor.assumeIsolated {
             AppNavigator(
                 dependencies: self.appDependencies(),
-                deeplinker: self.deeplinker()
+                deeplinker: self.deeplinker(),
+                analytics: self.localAnalytics()
             )
         } }
         .singleton
@@ -75,7 +94,8 @@ extension Container {
                 preferences: dependencies.preferences,
                 player: dependencies.player,
                 articlesService: dependencies.articlesService,
-                adsService: dependencies.adsService
+                adsService: dependencies.adsService,
+                analytics: dependencies.analytics
             )
         } }
         .singleton

--- a/Azkar/Sources/Navigation/AppDependencies.swift
+++ b/Azkar/Sources/Navigation/AppDependencies.swift
@@ -11,6 +11,7 @@ final class AppDependencies {
     let preferences: Preferences
     let player: Player
     let preferencesDatabase: PreferencesDatabase
+    let analytics: AppAnalyticsTracking
     let analyticsDatabase: AnalyticsDatabaseService?
     let articlesService: ArticlesServiceType
     let adsService: AdsServiceType
@@ -19,17 +20,19 @@ final class AppDependencies {
         AzkarDatabase(language: preferences.contentLanguage)
     }
 
-    init(preferences: Preferences, player: Player) {
+    init(
+        preferences: Preferences,
+        player: Player,
+        analytics: AppAnalyticsTracking,
+        analyticsDatabase: AnalyticsDatabaseService?
+    ) {
         self.preferences = preferences
         self.player = player
+        self.analytics = analytics
 
         let appGroupFolder = FileManager.default.appGroupContainerURL
         let language = preferences.contentLanguage.fallbackLanguage
-        let analyticsDatabasePath = appGroupFolder
-            .appendingPathComponent("analytics.db")
-            .absoluteString
-
-        analyticsDatabase = try? AnalyticsSQLiteDatabaseService(databasePath: analyticsDatabasePath)
+        self.analyticsDatabase = analyticsDatabase
 
         let services: (ArticlesServiceType, AdsServiceType, PreferencesDatabase)
 

--- a/Azkar/Sources/Navigation/AppFlowView.swift
+++ b/Azkar/Sources/Navigation/AppFlowView.swift
@@ -205,6 +205,7 @@ private struct CategoryRouteView: View {
                 title: category.title,
                 azkar: dependencies.azkar(for: category),
                 preferences: dependencies.preferences,
+                analytics: dependencies.analytics,
                 selectedPagePublisher: navigator.selectedPagePublisher,
                 initialPage: initialPage
             )
@@ -240,6 +241,7 @@ private struct StandaloneZikrRouteView: View {
                 title: "",
                 azkar: [zikrViewModel],
                 preferences: dependencies.preferences,
+                analytics: dependencies.analytics,
                 selectedPagePublisher: Empty().eraseToAnyPublisher(),
                 initialPage: 0
             )

--- a/Azkar/Sources/Navigation/AppNavigator.swift
+++ b/Azkar/Sources/Navigation/AppNavigator.swift
@@ -46,47 +46,47 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
 
     func showCategory(_ category: ZikrCategory) {
         selectedZikrPageIndex.send(0)
-        analytics.track(.categoryOpened(
-            category: category,
-            source: "main_menu",
+        analytics.navigation.openedCategory(
+            category,
+            source: .mainMenu,
             initialPage: nil
-        ))
+        )
         stack.append(.category(category))
     }
 
     func showCategoryReader(category: ZikrCategory, initialPage: Int) {
         selectedZikrPageIndex.send(initialPage)
-        analytics.track(.categoryOpened(
-            category: category,
-            source: "category_reader",
+        analytics.navigation.openedCategory(
+            category,
+            source: .categoryReader,
             initialPage: initialPage
-        ))
+        )
         stack.append(.categoryReader(.init(category: category, initialPage: initialPage)))
     }
 
     func showZikr(_ zikr: Zikr) {
-        showZikr(zikr, source: "main_menu")
+        showZikr(zikr, source: .mainMenu)
     }
 
     func showRecentZikr(id: Zikr.ID) {
         guard let zikr = try? dependencies.databaseService.getZikr(id, language: dependencies.preferences.contentLanguage) else {
             return
         }
-        showZikr(zikr, source: "recent")
+        showZikr(zikr, source: .recent)
     }
 
     func showSearchResult(_ result: SearchResultZikr, query: String) {
         selectedZikrPageIndex.send(0)
-        analytics.track(.searchResultOpened(
+        analytics.search.openedResult(
             id: result.zikrId,
             language: result.language,
             queryLength: query.count
-        ))
-        analytics.track(.zikrOpened(
+        )
+        analytics.navigation.openedZikr(
             id: result.zikrId,
             language: result.language,
-            source: "search"
-        ))
+            source: .search
+        )
         storeOpenedZikr(result.zikrId, language: result.language)
         stack.append(.standaloneZikr(.init(
             zikrId: result.zikrId,
@@ -97,7 +97,7 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
     }
 
     func showArticle(_ article: Article) {
-        analytics.track(.articleOpened(id: article.id, source: "main_menu"))
+        analytics.navigation.openedArticle(id: article.id, source: .mainMenu)
         stack.append(.article(article))
         dependencies.articlesService.sendAnalyticsEvent(.view, articleId: article.id)
     }
@@ -108,17 +108,17 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
     ) {
         selectedZikrPageIndex.send(0)
         currentCategoryContext = nil
-        let source: String
+        let source: AppAnalyticsSource
         switch presentationStyle {
         case .push:
-            source = "push"
+            source = .push
         case .sheet:
-            source = "sheet"
+            source = .sheet
         }
-        analytics.track(.settingsOpened(
+        analytics.settings.opened(
             source: source,
-            destination: initialDestination?.analyticsName ?? "root"
-        ))
+            destination: initialDestination?.analyticsName ?? .root
+        )
 
         let context = SettingsFlowContext(initialDestination: initialDestination)
         switch presentationStyle {
@@ -147,13 +147,13 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
 
 private extension AppNavigator {
 
-    func showZikr(_ zikr: Zikr, source: String) {
+    func showZikr(_ zikr: Zikr, source: AppAnalyticsSource) {
         selectedZikrPageIndex.send(0)
-        analytics.track(.zikrOpened(
+        analytics.navigation.openedZikr(
             id: zikr.id,
             language: zikr.language,
             source: source
-        ))
+        )
         storeOpenedZikr(zikr.id, language: zikr.language)
         stack.append(.standaloneZikr(.init(
             zikrId: zikr.id,
@@ -190,21 +190,21 @@ private extension AppNavigator {
             resetToRoot()
 
         case .settings(let destination):
-            analytics.track(.settingsOpened(
-                source: "deeplink",
+            analytics.settings.opened(
+                source: .deeplink,
                 destination: destination.analyticsName
-            ))
+            )
             replaceStackForDeepLink(with: .settings(.init(initialDestination: destination)))
 
         case .azkar(let category):
             guard currentCategoryContext != category else {
                 return
             }
-            analytics.track(.categoryOpened(
-                category: category,
-                source: "deeplink",
+            analytics.navigation.openedCategory(
+                category,
+                source: .deeplink,
                 initialPage: nil
-            ))
+            )
             replaceStackForDeepLink(with: .category(category))
 
         case .categoryZikr(let category, let id):
@@ -212,22 +212,22 @@ private extension AppNavigator {
             guard let index = azkar.firstIndex(where: { $0.zikr.id == id }) else {
                 return
             }
-            analytics.track(.categoryOpened(
-                category: category,
-                source: "deeplink",
+            analytics.navigation.openedCategory(
+                category,
+                source: .deeplink,
                 initialPage: index
-            ))
+            )
             replaceStackForDeepLink(with: .categoryReader(.init(category: category, initialPage: index)))
 
         case .zikr(let id):
             guard (try? dependencies.databaseService.getZikr(id, language: dependencies.preferences.contentLanguage)) != nil else {
                 return
             }
-            analytics.track(.zikrOpened(
+            analytics.navigation.openedZikr(
                 id: id,
                 language: dependencies.preferences.contentLanguage,
-                source: "deeplink"
-            ))
+                source: .deeplink
+            )
             replaceStackForDeepLink(with: .standaloneZikr(.init(
                 zikrId: id,
                 language: dependencies.preferences.contentLanguage,
@@ -241,10 +241,10 @@ private extension AppNavigator {
                     return
                 }
                 await MainActor.run {
-                    self.analytics.track(.articleOpened(
+                    self.analytics.navigation.openedArticle(
                         id: article.id,
-                        source: "deeplink"
-                    ))
+                        source: .deeplink
+                    )
                     self.replaceStackForDeepLink(with: .article(article))
                     self.dependencies.articlesService.sendAnalyticsEvent(.view, articleId: article.id)
                 }

--- a/Azkar/Sources/Navigation/AppNavigator.swift
+++ b/Azkar/Sources/Navigation/AppNavigator.swift
@@ -16,14 +16,20 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
 
     private let dependencies: AppDependencies
     private let deeplinker: Deeplinker
+    private let analytics: AppAnalyticsTracking
     private let selectedZikrPageIndex = CurrentValueSubject<Int, Never>(0)
 
     private var cancellables = Set<AnyCancellable>()
     private var currentCategoryContext: ZikrCategory?
 
-    init(dependencies: AppDependencies, deeplinker: Deeplinker) {
+    init(
+        dependencies: AppDependencies,
+        deeplinker: Deeplinker,
+        analytics: AppAnalyticsTracking
+    ) {
         self.dependencies = dependencies
         self.deeplinker = deeplinker
+        self.analytics = analytics
         observeDeepLinks()
         handlePendingDeepLinkIfNeeded()
     }
@@ -40,34 +46,47 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
 
     func showCategory(_ category: ZikrCategory) {
         selectedZikrPageIndex.send(0)
+        analytics.track(.categoryOpened(
+            category: category,
+            source: "main_menu",
+            initialPage: nil
+        ))
         stack.append(.category(category))
     }
 
     func showCategoryReader(category: ZikrCategory, initialPage: Int) {
         selectedZikrPageIndex.send(initialPage)
+        analytics.track(.categoryOpened(
+            category: category,
+            source: "category_reader",
+            initialPage: initialPage
+        ))
         stack.append(.categoryReader(.init(category: category, initialPage: initialPage)))
     }
 
     func showZikr(_ zikr: Zikr) {
-        selectedZikrPageIndex.send(0)
-        storeOpenedZikr(zikr.id, language: zikr.language)
-        stack.append(.standaloneZikr(.init(
-            zikrId: zikr.id,
-            language: zikr.language,
-            highlightPattern: nil,
-            isNested: true
-        )))
+        showZikr(zikr, source: "main_menu")
     }
 
     func showRecentZikr(id: Zikr.ID) {
         guard let zikr = try? dependencies.databaseService.getZikr(id, language: dependencies.preferences.contentLanguage) else {
             return
         }
-        showZikr(zikr)
+        showZikr(zikr, source: "recent")
     }
 
     func showSearchResult(_ result: SearchResultZikr, query: String) {
         selectedZikrPageIndex.send(0)
+        analytics.track(.searchResultOpened(
+            id: result.zikrId,
+            language: result.language,
+            queryLength: query.count
+        ))
+        analytics.track(.zikrOpened(
+            id: result.zikrId,
+            language: result.language,
+            source: "search"
+        ))
         storeOpenedZikr(result.zikrId, language: result.language)
         stack.append(.standaloneZikr(.init(
             zikrId: result.zikrId,
@@ -78,6 +97,7 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
     }
 
     func showArticle(_ article: Article) {
+        analytics.track(.articleOpened(id: article.id, source: "main_menu"))
         stack.append(.article(article))
         dependencies.articlesService.sendAnalyticsEvent(.view, articleId: article.id)
     }
@@ -88,6 +108,17 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
     ) {
         selectedZikrPageIndex.send(0)
         currentCategoryContext = nil
+        let source: String
+        switch presentationStyle {
+        case .push:
+            source = "push"
+        case .sheet:
+            source = "sheet"
+        }
+        analytics.track(.settingsOpened(
+            source: source,
+            destination: initialDestination?.analyticsName ?? "root"
+        ))
 
         let context = SettingsFlowContext(initialDestination: initialDestination)
         switch presentationStyle {
@@ -116,6 +147,22 @@ final class AppNavigator: ObservableObject, AppNavigationRouting {
 
 private extension AppNavigator {
 
+    func showZikr(_ zikr: Zikr, source: String) {
+        selectedZikrPageIndex.send(0)
+        analytics.track(.zikrOpened(
+            id: zikr.id,
+            language: zikr.language,
+            source: source
+        ))
+        storeOpenedZikr(zikr.id, language: zikr.language)
+        stack.append(.standaloneZikr(.init(
+            zikrId: zikr.id,
+            language: zikr.language,
+            highlightPattern: nil,
+            isNested: true
+        )))
+    }
+
     func observeDeepLinks() {
         deeplinker.routes
             .receive(on: DispatchQueue.main)
@@ -143,12 +190,21 @@ private extension AppNavigator {
             resetToRoot()
 
         case .settings(let destination):
+            analytics.track(.settingsOpened(
+                source: "deeplink",
+                destination: destination.analyticsName
+            ))
             replaceStackForDeepLink(with: .settings(.init(initialDestination: destination)))
 
         case .azkar(let category):
             guard currentCategoryContext != category else {
                 return
             }
+            analytics.track(.categoryOpened(
+                category: category,
+                source: "deeplink",
+                initialPage: nil
+            ))
             replaceStackForDeepLink(with: .category(category))
 
         case .categoryZikr(let category, let id):
@@ -156,12 +212,22 @@ private extension AppNavigator {
             guard let index = azkar.firstIndex(where: { $0.zikr.id == id }) else {
                 return
             }
+            analytics.track(.categoryOpened(
+                category: category,
+                source: "deeplink",
+                initialPage: index
+            ))
             replaceStackForDeepLink(with: .categoryReader(.init(category: category, initialPage: index)))
 
         case .zikr(let id):
             guard (try? dependencies.databaseService.getZikr(id, language: dependencies.preferences.contentLanguage)) != nil else {
                 return
             }
+            analytics.track(.zikrOpened(
+                id: id,
+                language: dependencies.preferences.contentLanguage,
+                source: "deeplink"
+            ))
             replaceStackForDeepLink(with: .standaloneZikr(.init(
                 zikrId: id,
                 language: dependencies.preferences.contentLanguage,
@@ -175,6 +241,10 @@ private extension AppNavigator {
                     return
                 }
                 await MainActor.run {
+                    self.analytics.track(.articleOpened(
+                        id: article.id,
+                        source: "deeplink"
+                    ))
                     self.replaceStackForDeepLink(with: .article(article))
                     self.dependencies.articlesService.sendAnalyticsEvent(.view, articleId: article.id)
                 }

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuView.swift
@@ -172,9 +172,7 @@ struct MainMenuView: View {
         if viewModel.searchQuery.isEmpty {
             SearchSuggestionsView(
                 viewModel: viewModel.searchSuggestionsViewModel,
-                onSearchSuggestionSelection: { query in
-                    viewModel.searchQuery = query
-                }
+                onSearchSuggestionSelection: viewModel.selectSearchSuggestion(_:)
             )
         } else {
             SearchResultsView(

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
@@ -26,7 +26,8 @@ final class MainMenuViewModel: ObservableObject {
         azkarDatabase: azkarDatabase,
         preferencesDatabase: preferencesDatabase,
         searchTokens: $searchTokens.eraseToAnyPublisher(),
-        searchQuery: searchQueryPublisher.removeDuplicates().eraseToAnyPublisher()
+        searchQuery: searchQueryPublisher.removeDuplicates().eraseToAnyPublisher(),
+        analytics: analytics
     )
     
     private(set) lazy var searchSuggestionsViewModel = SearchSuggestionsViewModel(
@@ -59,6 +60,7 @@ final class MainMenuViewModel: ObservableObject {
     let preferences: Preferences
     private let articlesService: ArticlesServiceType
     private let adsService: AdsServiceType
+    private let analytics: AppAnalyticsTracking
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -69,7 +71,8 @@ final class MainMenuViewModel: ObservableObject {
         preferences: Preferences,
         player: Player,
         articlesService: ArticlesServiceType,
-        adsService: AdsServiceType
+        adsService: AdsServiceType,
+        analytics: AppAnalyticsTracking
     ) {
         self.azkarDatabase = databaseService
         self.preferencesDatabase = preferencesDatabase
@@ -78,6 +81,7 @@ final class MainMenuViewModel: ObservableObject {
         self.player = player
         self.articlesService = articlesService
         self.adsService = adsService
+        self.analytics = analytics
                 
         if Date().isRamadan {
             var adhkar: [ZikrMenuItem] = []
@@ -208,6 +212,14 @@ final class MainMenuViewModel: ObservableObject {
     func navigateToArticle(_ article: Article) {
         navigator.showArticle(article)
     }
+
+    func selectSearchSuggestion(_ query: String) {
+        analytics.track(.searchSuggestionSelected(
+            queryLength: query.count,
+            source: "recent_query"
+        ))
+        searchQuery = query
+    }
     
     func navigateToSearchResult(_ searchResult: SearchResultZikr) {
         navigator.showSearchResult(searchResult, query: searchQuery)
@@ -266,7 +278,8 @@ extension MainMenuViewModel {
             preferences: Preferences.shared,
             player: .test,
             articlesService: DemoArticlesService(),
-            adsService: DemoAdsService()
+            adsService: DemoAdsService(),
+            analytics: NoopAppAnalytics()
         )
     }
     

--- a/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
+++ b/Azkar/Sources/Scenes/Main Menu/MainMenuViewModel.swift
@@ -214,10 +214,10 @@ final class MainMenuViewModel: ObservableObject {
     }
 
     func selectSearchSuggestion(_ query: String) {
-        analytics.track(.searchSuggestionSelected(
+        analytics.search.selectedSuggestion(
             queryLength: query.count,
-            source: "recent_query"
-        ))
+            source: .recentQuery
+        )
         searchQuery = query
     }
     

--- a/Azkar/Sources/Scenes/Root/ArticleShareActionHandler.swift
+++ b/Azkar/Sources/Scenes/Root/ArticleShareActionHandler.swift
@@ -10,8 +10,8 @@ import FactoryKit
 final class ArticleShareActionHandler {
 
     @Injected(\.appDependencies) private var dependencies: AppDependencies
+    @Injected(\.localAnalytics) private var analytics: AppAnalyticsTracking
     private let mailPresenter = FeedbackMailPresenter()
-
     func share(_ article: Article) {
         assert(Thread.isMainThread)
         guard let rootViewController = topViewController() else {
@@ -89,6 +89,7 @@ final class ArticleShareActionHandler {
         activityController.completionWithItemsHandler = { [articlesService] _, completed, _, _ in
             viewController.dismiss(animated: true)
             if completed {
+                self.analytics.track(.articleShared(id: article.id, format: "pdf"))
                 articlesService.sendAnalyticsEvent(.share, articleId: article.id)
             }
         }

--- a/Azkar/Sources/Scenes/Root/ArticleShareActionHandler.swift
+++ b/Azkar/Sources/Scenes/Root/ArticleShareActionHandler.swift
@@ -89,7 +89,7 @@ final class ArticleShareActionHandler {
         activityController.completionWithItemsHandler = { [articlesService] _, completed, _, _ in
             viewController.dismiss(animated: true)
             if completed {
-                self.analytics.track(.articleShared(id: article.id, format: "pdf"))
+                self.analytics.sharing.sharedArticle(id: article.id, format: .pdf)
                 articlesService.sendAnalyticsEvent(.share, articleId: article.id)
             }
         }

--- a/Azkar/Sources/Scenes/Search Results/SearchResultsViewModel.swift
+++ b/Azkar/Sources/Scenes/Search Results/SearchResultsViewModel.swift
@@ -77,15 +77,18 @@ final class SearchResultsViewModel: ObservableObject {
     }
     
     private let azkarDatabase: AzkarDatabase
+    private let analytics: AppAnalyticsTracking
     private var cancellables = Set<AnyCancellable>()
     
     init(
         azkarDatabase: AzkarDatabase,
         preferencesDatabase: PreferencesDatabase,
         searchTokens: AnyPublisher<[SearchToken], Never>,
-        searchQuery: AnyPublisher<String, Never>
+        searchQuery: AnyPublisher<String, Never>,
+        analytics: AppAnalyticsTracking
     ) {
         self.azkarDatabase = azkarDatabase
+        self.analytics = analytics
         searchTokens.assign(to: &$selectedTokens)
         searchQuery.map { _ in [] }.assign(to: &$searchResults)
         configureSearch(
@@ -146,6 +149,18 @@ final class SearchResultsViewModel: ObservableObject {
                         await preferencesDatabase.storeSearchQuery(query)
                     }
                 }
+
+                guard query.count >= 3 else {
+                    return
+                }
+
+                let resultCount = results.reduce(0) { $0 + $1.results.count }
+                self.analytics.track(.searchPerformed(
+                    queryLength: query.count,
+                    selectedTokenCount: self.selectedTokens.count,
+                    sectionCount: results.count,
+                    resultCount: resultCount
+                ))
             })
             .store(in: &cancellables)
         
@@ -166,7 +181,8 @@ extension SearchResultsViewModel {
             azkarDatabase: .init(language: Language.english),
             preferencesDatabase: MockPreferencesDatabase(),
             searchTokens: Empty().eraseToAnyPublisher(),
-            searchQuery: Empty().eraseToAnyPublisher()
+            searchQuery: Empty().eraseToAnyPublisher(),
+            analytics: NoopAppAnalytics()
         )
         vm.searchResults = [
             .init(title: "Placeholder", image: "book", results: [

--- a/Azkar/Sources/Scenes/Search Results/SearchResultsViewModel.swift
+++ b/Azkar/Sources/Scenes/Search Results/SearchResultsViewModel.swift
@@ -155,12 +155,12 @@ final class SearchResultsViewModel: ObservableObject {
                 }
 
                 let resultCount = results.reduce(0) { $0 + $1.results.count }
-                self.analytics.track(.searchPerformed(
+                self.analytics.search.performed(
                     queryLength: query.count,
                     selectedTokenCount: self.selectedTokens.count,
                     sectionCount: results.count,
                     resultCount: resultCount
-                ))
+                )
             })
             .store(in: &cancellables)
         

--- a/Azkar/Sources/Scenes/Settings/SettingsNavigation.swift
+++ b/Azkar/Sources/Scenes/Settings/SettingsNavigation.swift
@@ -58,7 +58,7 @@ final class SettingsNavigator: ObservableObject, SettingsNavigationRouting {
     }
 
     func show(_ destination: SettingsDestination) {
-        analytics.track(.settingsDetailOpened(destination: destination.analyticsName))
+        analytics.settings.openedDetail(destination.analyticsName)
         stack.append(destination)
     }
 
@@ -78,22 +78,22 @@ final class SettingsNavigator: ObservableObject, SettingsNavigationRouting {
 
 extension SettingsDestination {
 
-    var analyticsName: String {
+    var analyticsName: AppAnalyticsSettingsDestination {
         switch self {
         case .notificationsList:
-            return "notifications_list"
+            return .notificationsList
         case .appearance:
-            return "appearance"
+            return .appearance
         case .text:
-            return "text"
+            return .text
         case .counter:
-            return "counter"
+            return .counter
         case .reminders:
-            return "reminders"
+            return .reminders
         case .soundPicker:
-            return "sound_picker"
+            return .soundPicker
         case .aboutApp:
-            return "about_app"
+            return .aboutApp
         }
     }
 

--- a/Azkar/Sources/Scenes/Settings/SettingsNavigation.swift
+++ b/Azkar/Sources/Scenes/Settings/SettingsNavigation.swift
@@ -49,6 +49,7 @@ final class SettingsNavigator: ObservableObject, SettingsNavigationRouting {
 
     @Injected(\.preferences) private var preferences: Preferences
     @Injected(\.subscriptionManager) private var subscriptionManager: SubscriptionManagerType
+    @Injected(\.localAnalytics) private var analytics: AppAnalyticsTracking
 
     init(initialDestination: SettingsDestination? = nil) {
         if let initialDestination {
@@ -57,6 +58,7 @@ final class SettingsNavigator: ObservableObject, SettingsNavigationRouting {
     }
 
     func show(_ destination: SettingsDestination) {
+        analytics.track(.settingsDetailOpened(destination: destination.analyticsName))
         stack.append(destination)
     }
 
@@ -72,4 +74,27 @@ final class SettingsNavigator: ObservableObject, SettingsNavigationRouting {
             preselectedCollection: preferences.zikrCollectionSource
         ))
     }
+}
+
+extension SettingsDestination {
+
+    var analyticsName: String {
+        switch self {
+        case .notificationsList:
+            return "notifications_list"
+        case .appearance:
+            return "appearance"
+        case .text:
+            return "text"
+        case .counter:
+            return "counter"
+        case .reminders:
+            return "reminders"
+        case .soundPicker:
+            return "sound_picker"
+        case .aboutApp:
+            return "about_app"
+        }
+    }
+
 }

--- a/Azkar/Sources/Scenes/Zikr Pages/ZikrPagesViewModel.swift
+++ b/Azkar/Sources/Scenes/Zikr Pages/ZikrPagesViewModel.swift
@@ -250,10 +250,10 @@ final class ZikrPagesViewModel: ObservableObject {
                 let hasRemainingRepeats = count < totalCount
                 setHasRemainingRepeats(hasRemainingRepeats)
                 if !hasRemainingRepeats {
-                    self.analytics.track(.categoryCompleted(
-                        category: category,
+                    self.analytics.category.completed(
+                        category,
                         totalRepeats: totalCount
-                    ))
+                    )
                     Task {
                         try await zikrCounter.markCategoryAsCompleted(category)
                     }

--- a/Azkar/Sources/Scenes/Zikr Pages/ZikrPagesViewModel.swift
+++ b/Azkar/Sources/Scenes/Zikr Pages/ZikrPagesViewModel.swift
@@ -9,7 +9,6 @@ import ActivityKit
 
 @MainActor
 final class ZikrPagesViewModel: ObservableObject {
-    
     enum PageType: Hashable, Identifiable {
         var id: String {
             switch self {
@@ -17,7 +16,6 @@ final class ZikrPagesViewModel: ObservableObject {
             case .readingCompletion: return "readingCompletion"
             }
         }
-        
         case zikr(ZikrViewModel)
         case readingCompletion
     }
@@ -27,11 +25,10 @@ final class ZikrPagesViewModel: ObservableObject {
     let title: String
     let azkar: [ZikrViewModel]
     let pages: [PageType]
-    let preferences: Preferences
+    let preferences: Preferences; let analytics: AppAnalyticsTracking
     let zikrCounter: ZikrCounterType
     let selectedPage: AnyPublisher<Int, Never>
     let initialPage: Int
-    
     @Published var page = 0
     @Published var hasRemainingRepeats = true
     @Published var counterPosition: CounterPosition
@@ -46,8 +43,7 @@ final class ZikrPagesViewModel: ObservableObject {
     private var liveActivityUpdateTask: Task<Void, Never>?
     private var liveActivitySessionID: UUID?
     private var liveActivityUpdateSequence = 0
-    private var completedRepeatsInCategory = 0
-    private var totalRepeatsInCategory: Int { azkar.reduce(0) { $0 + $1.zikr.repeats } }
+    private var completedRepeatsInCategory = 0; private var totalRepeatsInCategory: Int { azkar.reduce(0) { $0 + $1.zikr.repeats } }
 
     init(
         navigator: any AppNavigationRouting,
@@ -55,6 +51,7 @@ final class ZikrPagesViewModel: ObservableObject {
         title: String,
         azkar: [ZikrViewModel],
         preferences: Preferences,
+        analytics: AppAnalyticsTracking,
         zikrCounter: ZikrCounterType = ZikrCounter.shared,
         selectedPagePublisher: AnyPublisher<Int, Never>,
         initialPage: Int
@@ -63,6 +60,7 @@ final class ZikrPagesViewModel: ObservableObject {
         self.category = category
         self.title = title
         self.preferences = preferences
+        self.analytics = analytics
         self.zikrCounter = zikrCounter
         self.azkar = azkar
         self.selectedPage = selectedPagePublisher
@@ -252,6 +250,10 @@ final class ZikrPagesViewModel: ObservableObject {
                 let hasRemainingRepeats = count < totalCount
                 setHasRemainingRepeats(hasRemainingRepeats)
                 if !hasRemainingRepeats {
+                    self.analytics.track(.categoryCompleted(
+                        category: category,
+                        totalRepeats: totalCount
+                    ))
                     Task {
                         try await zikrCounter.markCategoryAsCompleted(category)
                     }
@@ -330,6 +332,7 @@ final class ZikrPagesViewModel: ObservableObject {
             title: ZikrCategory.morning.title,
             azkar: [.demo()],
             preferences: Preferences.shared,
+            analytics: NoopAppAnalytics(),
             selectedPagePublisher: PassthroughSubject<Int, Never>().eraseToAnyPublisher(),
             initialPage: 0
         )

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareActionHandler.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareActionHandler.swift
@@ -53,7 +53,7 @@ private extension ZikrShareActionHandler {
 
         if options.actionType == .copyText {
             UIPasteboard.general.string = text
-            analytics.track(.zikrShared(id: zikr.id, shareType: "text", action: "copy"))
+            analytics.sharing.sharedZikr(id: zikr.id, shareType: .text, action: .copy)
         } else if options.actionType == .sheet {
             let activityController = UIActivityViewController(
                 activityItems: [text],
@@ -70,7 +70,7 @@ private extension ZikrShareActionHandler {
                 guard completed else {
                     return
                 }
-                self.analytics.track(.zikrShared(id: zikr.id, shareType: "text", action: "sheet"))
+                self.analytics.sharing.sharedZikr(id: zikr.id, shareType: .text, action: .sheet)
             }
 
             rootViewController.present(activityController, animated: true)
@@ -114,7 +114,7 @@ private extension ZikrShareActionHandler {
 
         if options.actionType == .saveImage {
             UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
-            analytics.track(.zikrShared(id: zikr.id, shareType: "image", action: "save"))
+            analytics.sharing.sharedZikr(id: zikr.id, shareType: .image, action: .save)
             return
         }
 
@@ -143,7 +143,7 @@ private extension ZikrShareActionHandler {
             guard completed else {
                 return
             }
-            self.analytics.track(.zikrShared(id: zikr.id, shareType: "image", action: "sheet"))
+            self.analytics.sharing.sharedZikr(id: zikr.id, shareType: .image, action: .sheet)
         }
 
         rootViewController.present(activityController, animated: true)

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareActionHandler.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareActionHandler.swift
@@ -9,8 +9,8 @@ final class ZikrShareActionHandler {
     @Injected(\.preferences) private var preferences: Preferences
     @Injected(\.player) private var player: Player
     @Injected(\.subscriptionManager) private var subscriptionManager: SubscriptionManagerType
+    @Injected(\.localAnalytics) private var analytics: AppAnalyticsTracking
     private let mailPresenter = FeedbackMailPresenter()
-
     func handle(_ options: ZikrShareOptionsView.ShareOptions, for zikr: Zikr) {
         if options.containsProItem, subscriptionManager.isProUser() == false {
             subscriptionManager.presentPaywall(
@@ -53,6 +53,7 @@ private extension ZikrShareActionHandler {
 
         if options.actionType == .copyText {
             UIPasteboard.general.string = text
+            analytics.track(.zikrShared(id: zikr.id, shareType: "text", action: "copy"))
         } else if options.actionType == .sheet {
             let activityController = UIActivityViewController(
                 activityItems: [text],
@@ -64,6 +65,13 @@ private extension ZikrShareActionHandler {
             activityController.excludedActivityTypes = [
                 .init(rawValue: "com.apple.reminders.sharingextension")
             ]
+
+            activityController.completionWithItemsHandler = { _, completed, _, _ in
+                guard completed else {
+                    return
+                }
+                self.analytics.track(.zikrShared(id: zikr.id, shareType: "text", action: "sheet"))
+            }
 
             rootViewController.present(activityController, animated: true)
         }
@@ -106,6 +114,7 @@ private extension ZikrShareActionHandler {
 
         if options.actionType == .saveImage {
             UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+            analytics.track(.zikrShared(id: zikr.id, shareType: "image", action: "save"))
             return
         }
 
@@ -129,6 +138,13 @@ private extension ZikrShareActionHandler {
         activityController.excludedActivityTypes = [
             .init(rawValue: "com.apple.reminders.sharingextension")
         ]
+
+        activityController.completionWithItemsHandler = { _, completed, _, _ in
+            guard completed else {
+                return
+            }
+            self.analytics.track(.zikrShared(id: zikr.id, shareType: "image", action: "sheet"))
+        }
 
         rootViewController.present(activityController, animated: true)
     }

--- a/Azkar/Sources/Services/AppAnalytics.swift
+++ b/Azkar/Sources/Services/AppAnalytics.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Extensions
+import DatabaseInteractors
+import AzkarServices
+
+protocol AppAnalyticsTracking {
+    func start()
+    func track(_ event: AppAnalyticsEvent)
+}
+
+final class AppAnalyticsStack {
+
+    let processedEventsStore: AnalyticsDatabaseService?
+    let localAnalytics: AppAnalyticsTracking
+
+    init(
+        preferences: Preferences = .shared,
+        notificationsHandler: NotificationsHandler = .shared
+    ) {
+        let databasePath = FileManager.default
+            .appGroupContainerURL
+            .appendingPathComponent("analytics.db")
+            .absoluteString
+
+        guard let database = try? AnalyticsSQLiteDatabase(databasePath: databasePath) else {
+            processedEventsStore = nil
+            localAnalytics = NoopAppAnalytics()
+            return
+        }
+
+        processedEventsStore = AnalyticsSQLiteDatabaseService(database: database)
+        localAnalytics = AppAnalytics(
+            store: LocalAnalyticsSQLiteStore(database: database),
+            preferences: preferences,
+            notificationsHandler: notificationsHandler
+        )
+    }
+
+}
+
+final class AppAnalytics: AppAnalyticsTracking {
+
+    private let recorder: LocalAnalyticsRecorder
+    private let usageTracker: AppUsageTracker
+    private var hasStarted = false
+
+    init(
+        store: LocalAnalyticsStore,
+        preferences: Preferences,
+        notificationsHandler: NotificationsHandler
+    ) {
+        let metadataProvider = AppAnalyticsMetadataProvider(preferences: preferences)
+        let recorder = LocalAnalyticsRecorder(
+            store: store,
+            commonMetadata: metadataProvider.metadata
+        )
+        self.recorder = recorder
+        usageTracker = AppUsageTracker(
+            recorder: recorder,
+            preferences: preferences,
+            notificationsHandler: notificationsHandler
+        )
+    }
+
+    func start() {
+        guard hasStarted == false else {
+            return
+        }
+        hasStarted = true
+        AnalyticsReporter.addTarget(LocalAnalyticsTarget(recorder: recorder))
+        usageTracker.start()
+    }
+
+    func track(_ event: AppAnalyticsEvent) {
+        Task {
+            await recorder.record(event)
+        }
+    }
+
+}
+
+final class NoopAppAnalytics: AppAnalyticsTracking {
+    func start() {}
+    func track(_ event: AppAnalyticsEvent) {}
+}

--- a/Azkar/Sources/Services/AppAnalytics.swift
+++ b/Azkar/Sources/Services/AppAnalytics.swift
@@ -20,7 +20,7 @@ final class AppAnalyticsStack {
         let databasePath = FileManager.default
             .appGroupContainerURL
             .appendingPathComponent("analytics.db")
-            .absoluteString
+            .path
 
         guard let database = try? AnalyticsSQLiteDatabase(databasePath: databasePath) else {
             processedEventsStore = nil

--- a/Azkar/Sources/Services/AppAnalyticsEvent.swift
+++ b/Azkar/Sources/Services/AppAnalyticsEvent.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Entities
+
+enum AppAnalyticsEvent {
+    case sessionStarted(source: String, isFirstLaunch: Bool)
+    case appFirstOpened
+    case appEntrypointUsed(source: String, target: String)
+    case notificationPermissionChanged(state: String)
+    case settingChanged(name: String, oldValue: String, newValue: String)
+    case categoryOpened(category: ZikrCategory, source: String, initialPage: Int?)
+    case zikrOpened(id: Zikr.ID, language: Language, source: String)
+    case searchResultOpened(id: Zikr.ID, language: Language, queryLength: Int)
+    case searchPerformed(
+        queryLength: Int,
+        selectedTokenCount: Int,
+        sectionCount: Int,
+        resultCount: Int
+    )
+    case searchSuggestionSelected(queryLength: Int, source: String)
+    case articleOpened(id: Article.ID, source: String)
+    case articleShared(id: Article.ID, format: String)
+    case zikrShared(id: Zikr.ID, shareType: String, action: String)
+    case settingsOpened(source: String, destination: String)
+    case settingsDetailOpened(destination: String)
+    case categoryCompleted(category: ZikrCategory, totalRepeats: Int)
+
+    var name: String {
+        switch self {
+        case .sessionStarted:
+            return "session_started"
+        case .appFirstOpened:
+            return "app_first_opened"
+        case .appEntrypointUsed:
+            return "app_entrypoint_used"
+        case .notificationPermissionChanged:
+            return "notification_permission_changed"
+        case .settingChanged:
+            return "setting_changed"
+        case .categoryOpened:
+            return "category_opened"
+        case .zikrOpened:
+            return "zikr_opened"
+        case .searchResultOpened:
+            return "search_result_opened"
+        case .searchPerformed:
+            return "search_performed"
+        case .searchSuggestionSelected:
+            return "search_suggestion_selected"
+        case .articleOpened:
+            return "article_opened"
+        case .articleShared:
+            return "article_shared"
+        case .zikrShared:
+            return "zikr_shared"
+        case .settingsOpened:
+            return "settings_opened"
+        case .settingsDetailOpened:
+            return "settings_detail_opened"
+        case .categoryCompleted:
+            return "category_completed"
+        }
+    }
+
+    var metadata: [String: Any] {
+        switch self {
+        case .sessionStarted(let source, let isFirstLaunch):
+            return [
+                "source": source,
+                "first_launch": isFirstLaunch
+            ]
+        case .appFirstOpened:
+            return [:]
+        case .appEntrypointUsed(let source, let target):
+            return [
+                "source": source,
+                "target": target
+            ]
+        case .notificationPermissionChanged(let state):
+            return [
+                "state": state
+            ]
+        case .settingChanged(let name, let oldValue, let newValue):
+            return [
+                "setting_name": name,
+                "old_value": oldValue,
+                "new_value": newValue
+            ]
+        case .categoryOpened(let category, let source, let initialPage):
+            var metadata: [String: Any] = [
+                "category": category.rawValue,
+                "source": source
+            ]
+            if let initialPage {
+                metadata["initial_page"] = initialPage
+            }
+            return metadata
+        case .zikrOpened(let id, let language, let source):
+            return [
+                "zikr_id": id,
+                "language": language.rawValue,
+                "source": source
+            ]
+        case .searchResultOpened(let id, let language, let queryLength):
+            return [
+                "zikr_id": id,
+                "language": language.rawValue,
+                "query_length": queryLength
+            ]
+        case .searchPerformed(let queryLength, let selectedTokenCount, let sectionCount, let resultCount):
+            return [
+                "query_length": queryLength,
+                "selected_token_count": selectedTokenCount,
+                "section_count": sectionCount,
+                "result_count": resultCount,
+                "has_results": resultCount > 0
+            ]
+        case .searchSuggestionSelected(let queryLength, let source):
+            return [
+                "query_length": queryLength,
+                "source": source
+            ]
+        case .articleOpened(let id, let source):
+            return [
+                "article_id": id,
+                "source": source
+            ]
+        case .articleShared(let id, let format):
+            return [
+                "article_id": id,
+                "format": format
+            ]
+        case .zikrShared(let id, let shareType, let action):
+            return [
+                "zikr_id": id,
+                "share_type": shareType,
+                "action": action
+            ]
+        case .settingsOpened(let source, let destination):
+            return [
+                "source": source,
+                "destination": destination
+            ]
+        case .settingsDetailOpened(let destination):
+            return [
+                "destination": destination
+            ]
+        case .categoryCompleted(let category, let totalRepeats):
+            return [
+                "category": category.rawValue,
+                "total_repeats": totalRepeats
+            ]
+        }
+    }
+}

--- a/Azkar/Sources/Services/AppAnalyticsEvent.swift
+++ b/Azkar/Sources/Services/AppAnalyticsEvent.swift
@@ -1,14 +1,110 @@
 import Foundation
 import Entities
 
+enum AppAnalyticsSource: String {
+    case appLaunch = "app_launch"
+    case foreground
+    case notification
+    case quickAction = "quick_action"
+    case controlCenter = "control_center"
+    case deeplink
+    case spotlight
+    case mainMenu = "main_menu"
+    case categoryReader = "category_reader"
+    case recent
+    case search
+    case recentQuery = "recent_query"
+    case push
+    case sheet
+}
+
+enum AppAnalyticsEntrypointTarget {
+    case home
+    case settings
+    case category(ZikrCategory)
+    case categoryZikr(ZikrCategory)
+    case zikr
+    case article
+    case hadith
+    case raw(String)
+
+    var analyticsValue: String {
+        switch self {
+        case .home:
+            return "home"
+        case .settings:
+            return "settings"
+        case .category(let category):
+            return "category_\(category.rawValue)"
+        case .categoryZikr(let category):
+            return "category_zikr_\(category.rawValue)"
+        case .zikr:
+            return "zikr"
+        case .article:
+            return "article"
+        case .hadith:
+            return "hadith"
+        case .raw(let value):
+            return value
+        }
+    }
+}
+
+enum AppAnalyticsSetting: String {
+    case contentLanguage = "content_language"
+    case zikrCollectionSource = "zikr_collection_source"
+    case colorTheme = "color_theme"
+    case appTheme = "app_theme"
+    case zikrReadingMode = "zikr_reading_mode"
+    case counterType = "counter_type"
+    case counterPosition = "counter_position"
+    case enableAdhkarReminder = "enable_adhkar_reminder"
+    case enableJumuaReminder = "enable_jumua_reminder"
+    case transliterationType = "transliteration_type"
+    case appIcon = "app_icon"
+}
+
+enum AppAnalyticsSettingsDestination: String {
+    case root
+    case notificationsList = "notifications_list"
+    case appearance
+    case text
+    case counter
+    case reminders
+    case soundPicker = "sound_picker"
+    case aboutApp = "about_app"
+}
+
+enum AppAnalyticsShareType: String {
+    case text
+    case image
+}
+
+enum AppAnalyticsShareAction: String {
+    case copy
+    case sheet
+    case save
+}
+
+enum AppAnalyticsArticleShareFormat: String {
+    case pdf
+}
+
+enum AppAnalyticsNotificationPermissionState: String {
+    case notDetermined = "not_determined"
+    case denied
+    case grantedNoSound = "granted_no_sound"
+    case granted
+}
+
 enum AppAnalyticsEvent {
-    case sessionStarted(source: String, isFirstLaunch: Bool)
+    case sessionStarted(source: AppAnalyticsSource, isFirstLaunch: Bool)
     case appFirstOpened
-    case appEntrypointUsed(source: String, target: String)
-    case notificationPermissionChanged(state: String)
-    case settingChanged(name: String, oldValue: String, newValue: String)
-    case categoryOpened(category: ZikrCategory, source: String, initialPage: Int?)
-    case zikrOpened(id: Zikr.ID, language: Language, source: String)
+    case appEntrypointUsed(source: AppAnalyticsSource, target: AppAnalyticsEntrypointTarget)
+    case notificationPermissionChanged(state: AppAnalyticsNotificationPermissionState)
+    case settingChanged(setting: AppAnalyticsSetting, oldValue: String, newValue: String)
+    case categoryOpened(category: ZikrCategory, source: AppAnalyticsSource, initialPage: Int?)
+    case zikrOpened(id: Zikr.ID, language: Language, source: AppAnalyticsSource)
     case searchResultOpened(id: Zikr.ID, language: Language, queryLength: Int)
     case searchPerformed(
         queryLength: Int,
@@ -16,12 +112,12 @@ enum AppAnalyticsEvent {
         sectionCount: Int,
         resultCount: Int
     )
-    case searchSuggestionSelected(queryLength: Int, source: String)
-    case articleOpened(id: Article.ID, source: String)
-    case articleShared(id: Article.ID, format: String)
-    case zikrShared(id: Zikr.ID, shareType: String, action: String)
-    case settingsOpened(source: String, destination: String)
-    case settingsDetailOpened(destination: String)
+    case searchSuggestionSelected(queryLength: Int, source: AppAnalyticsSource)
+    case articleOpened(id: Article.ID, source: AppAnalyticsSource)
+    case articleShared(id: Article.ID, format: AppAnalyticsArticleShareFormat)
+    case zikrShared(id: Zikr.ID, shareType: AppAnalyticsShareType, action: AppAnalyticsShareAction)
+    case settingsOpened(source: AppAnalyticsSource, destination: AppAnalyticsSettingsDestination)
+    case settingsDetailOpened(destination: AppAnalyticsSettingsDestination)
     case categoryCompleted(category: ZikrCategory, totalRepeats: Int)
 
     var name: String {
@@ -64,31 +160,23 @@ enum AppAnalyticsEvent {
     var metadata: [String: Any] {
         switch self {
         case .sessionStarted(let source, let isFirstLaunch):
-            return [
-                "source": source,
-                "first_launch": isFirstLaunch
-            ]
+            return ["source": source.rawValue, "first_launch": isFirstLaunch]
         case .appFirstOpened:
             return [:]
         case .appEntrypointUsed(let source, let target):
-            return [
-                "source": source,
-                "target": target
-            ]
+            return ["source": source.rawValue, "target": target.analyticsValue]
         case .notificationPermissionChanged(let state):
+            return ["state": state.rawValue]
+        case .settingChanged(let setting, let oldValue, let newValue):
             return [
-                "state": state
-            ]
-        case .settingChanged(let name, let oldValue, let newValue):
-            return [
-                "setting_name": name,
+                "setting_name": setting.rawValue,
                 "old_value": oldValue,
                 "new_value": newValue
             ]
         case .categoryOpened(let category, let source, let initialPage):
             var metadata: [String: Any] = [
                 "category": category.rawValue,
-                "source": source
+                "source": source.rawValue
             ]
             if let initialPage {
                 metadata["initial_page"] = initialPage
@@ -98,7 +186,7 @@ enum AppAnalyticsEvent {
             return [
                 "zikr_id": id,
                 "language": language.rawValue,
-                "source": source
+                "source": source.rawValue
             ]
         case .searchResultOpened(let id, let language, let queryLength):
             return [
@@ -115,40 +203,23 @@ enum AppAnalyticsEvent {
                 "has_results": resultCount > 0
             ]
         case .searchSuggestionSelected(let queryLength, let source):
-            return [
-                "query_length": queryLength,
-                "source": source
-            ]
+            return ["query_length": queryLength, "source": source.rawValue]
         case .articleOpened(let id, let source):
-            return [
-                "article_id": id,
-                "source": source
-            ]
+            return ["article_id": id, "source": source.rawValue]
         case .articleShared(let id, let format):
-            return [
-                "article_id": id,
-                "format": format
-            ]
+            return ["article_id": id, "format": format.rawValue]
         case .zikrShared(let id, let shareType, let action):
             return [
                 "zikr_id": id,
-                "share_type": shareType,
-                "action": action
+                "share_type": shareType.rawValue,
+                "action": action.rawValue
             ]
         case .settingsOpened(let source, let destination):
-            return [
-                "source": source,
-                "destination": destination
-            ]
+            return ["source": source.rawValue, "destination": destination.rawValue]
         case .settingsDetailOpened(let destination):
-            return [
-                "destination": destination
-            ]
+            return ["destination": destination.rawValue]
         case .categoryCompleted(let category, let totalRepeats):
-            return [
-                "category": category.rawValue,
-                "total_repeats": totalRepeats
-            ]
+            return ["category": category.rawValue, "total_repeats": totalRepeats]
         }
     }
 }

--- a/Azkar/Sources/Services/AppAnalyticsMetadataProvider.swift
+++ b/Azkar/Sources/Services/AppAnalyticsMetadataProvider.swift
@@ -1,0 +1,75 @@
+import Foundation
+import UIKit
+
+struct AppAnalyticsMetadataProvider {
+
+    private let preferences: Preferences
+    private let subscriptionManager: SubscriptionManagerType
+    private let defaults: UserDefaults
+
+    init(
+        preferences: Preferences,
+        subscriptionManager: SubscriptionManagerType = SubscriptionManagerFactory.create(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.preferences = preferences
+        self.subscriptionManager = subscriptionManager
+        self.defaults = defaults
+    }
+
+    func metadata() -> [String: Any] {
+        [
+            "app_version": appVersion,
+            "build_number": buildNumber,
+            "os_version": UIDevice.current.systemVersion,
+            "device_idiom": deviceIdiom,
+            "content_language": preferences.contentLanguage.rawValue,
+            "interface_language": Locale.preferredLanguages.first ?? Locale.current.identifier,
+            "is_pro_user": subscriptionManager.isProUser(),
+            "days_since_first_open": daysSinceFirstOpen
+        ]
+    }
+
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    }
+
+    private var buildNumber: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+    }
+
+    private var deviceIdiom: String {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .phone:
+            return "iphone"
+        case .pad:
+            return "ipad"
+        case .mac:
+            return "mac"
+        case .tv:
+            return "tv"
+        case .carPlay:
+            return "carplay"
+        case .unspecified:
+            return "unspecified"
+        @unknown default:
+            return "unknown"
+        }
+    }
+
+    private var daysSinceFirstOpen: Int {
+        let firstOpenDate = ensureFirstOpenDate()
+        return Calendar.current.dateComponents([.day], from: firstOpenDate, to: Date()).day ?? 0
+    }
+
+    private func ensureFirstOpenDate() -> Date {
+        if let date = defaults.object(forKey: Keys.firstOpenDate) as? Date {
+            return date
+        }
+
+        let date = Date()
+        defaults.set(date, forKey: Keys.firstOpenDate)
+        return date
+    }
+
+}

--- a/Azkar/Sources/Services/AppAnalyticsScopes.swift
+++ b/Azkar/Sources/Services/AppAnalyticsScopes.swift
@@ -1,0 +1,118 @@
+import Entities
+
+struct AppSessionAnalytics {
+    let track: (AppAnalyticsEvent) -> Void
+
+    func started(source: AppAnalyticsSource, isFirstLaunch: Bool) {
+        track(.sessionStarted(source: source, isFirstLaunch: isFirstLaunch))
+    }
+
+    func firstOpened() {
+        track(.appFirstOpened)
+    }
+}
+
+struct AppEntrypointAnalytics {
+    let track: (AppAnalyticsEvent) -> Void
+
+    func used(source: AppAnalyticsSource, target: AppAnalyticsEntrypointTarget) {
+        track(.appEntrypointUsed(source: source, target: target))
+    }
+}
+
+struct AppNavigationAnalytics {
+    let track: (AppAnalyticsEvent) -> Void
+
+    func openedCategory(_ category: ZikrCategory, source: AppAnalyticsSource, initialPage: Int? = nil) {
+        track(.categoryOpened(category: category, source: source, initialPage: initialPage))
+    }
+
+    func openedZikr(id: Zikr.ID, language: Language, source: AppAnalyticsSource) {
+        track(.zikrOpened(id: id, language: language, source: source))
+    }
+
+    func openedArticle(id: Article.ID, source: AppAnalyticsSource) {
+        track(.articleOpened(id: id, source: source))
+    }
+}
+
+struct AppSearchAnalytics {
+    let track: (AppAnalyticsEvent) -> Void
+
+    func performed(
+        queryLength: Int,
+        selectedTokenCount: Int,
+        sectionCount: Int,
+        resultCount: Int
+    ) {
+        track(.searchPerformed(
+            queryLength: queryLength,
+            selectedTokenCount: selectedTokenCount,
+            sectionCount: sectionCount,
+            resultCount: resultCount
+        ))
+    }
+
+    func openedResult(id: Zikr.ID, language: Language, queryLength: Int) {
+        track(.searchResultOpened(id: id, language: language, queryLength: queryLength))
+    }
+
+    func selectedSuggestion(queryLength: Int, source: AppAnalyticsSource) {
+        track(.searchSuggestionSelected(queryLength: queryLength, source: source))
+    }
+}
+
+struct AppSharingAnalytics {
+    let track: (AppAnalyticsEvent) -> Void
+
+    func sharedArticle(id: Article.ID, format: AppAnalyticsArticleShareFormat) {
+        track(.articleShared(id: id, format: format))
+    }
+
+    func sharedZikr(id: Zikr.ID, shareType: AppAnalyticsShareType, action: AppAnalyticsShareAction) {
+        track(.zikrShared(id: id, shareType: shareType, action: action))
+    }
+}
+
+struct AppSettingsAnalytics {
+    let track: (AppAnalyticsEvent) -> Void
+
+    func opened(source: AppAnalyticsSource, destination: AppAnalyticsSettingsDestination) {
+        track(.settingsOpened(source: source, destination: destination))
+    }
+
+    func openedDetail(_ destination: AppAnalyticsSettingsDestination) {
+        track(.settingsDetailOpened(destination: destination))
+    }
+
+    func changed(_ setting: AppAnalyticsSetting, oldValue: String, newValue: String) {
+        track(.settingChanged(setting: setting, oldValue: oldValue, newValue: newValue))
+    }
+}
+
+struct AppPermissionsAnalytics {
+    let track: (AppAnalyticsEvent) -> Void
+
+    func changedNotificationPermission(_ state: AppAnalyticsNotificationPermissionState) {
+        track(.notificationPermissionChanged(state: state))
+    }
+}
+
+struct AppCategoryAnalytics {
+    let track: (AppAnalyticsEvent) -> Void
+
+    func completed(_ category: ZikrCategory, totalRepeats: Int) {
+        track(.categoryCompleted(category: category, totalRepeats: totalRepeats))
+    }
+}
+
+extension AppAnalyticsTracking {
+    var session: AppSessionAnalytics { AppSessionAnalytics(track: track) }
+    var entrypoint: AppEntrypointAnalytics { AppEntrypointAnalytics(track: track) }
+    var navigation: AppNavigationAnalytics { AppNavigationAnalytics(track: track) }
+    var search: AppSearchAnalytics { AppSearchAnalytics(track: track) }
+    var sharing: AppSharingAnalytics { AppSharingAnalytics(track: track) }
+    var settings: AppSettingsAnalytics { AppSettingsAnalytics(track: track) }
+    var permissions: AppPermissionsAnalytics { AppPermissionsAnalytics(track: track) }
+    var category: AppCategoryAnalytics { AppCategoryAnalytics(track: track) }
+}

--- a/Azkar/Sources/Services/AppUsageTracker.swift
+++ b/Azkar/Sources/Services/AppUsageTracker.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Combine
+import UIKit
+import AzkarServices
+
+final class AppUsageTracker {
+
+    private let recorder: LocalAnalyticsRecorder
+    private let preferences: Preferences
+    private let notificationsHandler: NotificationsHandler
+
+    private let sessionTimeout: TimeInterval = 30 * 60
+    private let retentionInterval: TimeInterval = 180 * 24 * 60 * 60
+
+    private var currentSessionId: String?
+    private var lastBackgroundAt: Date?
+    private var cancellables = Set<AnyCancellable>()
+    private var hasStarted = false
+
+    init(
+        recorder: LocalAnalyticsRecorder,
+        preferences: Preferences,
+        notificationsHandler: NotificationsHandler
+    ) {
+        self.recorder = recorder
+        self.preferences = preferences
+        self.notificationsHandler = notificationsHandler
+    }
+
+    func start() {
+        guard hasStarted == false else {
+            return
+        }
+        hasStarted = true
+
+        observeLifecycle()
+        observeNotificationPermissions()
+        observeSettingChanges()
+
+        beginSessionIfNeeded(source: "app_launch")
+        Task {
+            await recorder.cleanup(retainingEventsFor: retentionInterval)
+        }
+    }
+
+    private func observeLifecycle() {
+        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                self?.beginSessionIfNeeded(source: "foreground")
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
+            .sink { [weak self] _ in
+                guard let self else {
+                    return
+                }
+                self.lastBackgroundAt = Date()
+                let recorder = self.recorder
+                let retentionInterval = self.retentionInterval
+                Task {
+                    await recorder.cleanup(retainingEventsFor: retentionInterval)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func observeNotificationPermissions() {
+        notificationsHandler.notificationsPermissionStatePublisher
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] state in
+                self?.track(.notificationPermissionChanged(state: state.analyticsValue))
+            }
+            .store(in: &cancellables)
+    }
+
+    private func observeSettingChanges() {
+        observeSetting(
+            name: "content_language",
+            publisher: preferences.$contentLanguage.eraseToAnyPublisher(),
+            serialize: { $0.rawValue }
+        )
+        observeSetting(
+            name: "zikr_collection_source",
+            publisher: preferences.$zikrCollectionSource.eraseToAnyPublisher(),
+            serialize: { $0.rawValue }
+        )
+        observeSetting(
+            name: "color_theme",
+            publisher: preferences.$colorTheme.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+        observeSetting(
+            name: "app_theme",
+            publisher: preferences.$appTheme.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+        observeSetting(
+            name: "zikr_reading_mode",
+            publisher: preferences.$zikrReadingMode.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+        observeSetting(
+            name: "counter_type",
+            publisher: preferences.$counterType.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+        observeSetting(
+            name: "counter_position",
+            publisher: preferences.$counterPosition.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+        observeSetting(
+            name: "enable_adhkar_reminder",
+            publisher: preferences.$enableAdhkarReminder.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+        observeSetting(
+            name: "enable_jumua_reminder",
+            publisher: preferences.$enableJumuaReminder.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+        observeSetting(
+            name: "transliteration_type",
+            publisher: preferences.$transliterationType.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+        observeSetting(
+            name: "app_icon",
+            publisher: preferences.$appIcon.eraseToAnyPublisher(),
+            serialize: String.init(describing:)
+        )
+    }
+
+    private func observeSetting<T: Equatable>(
+        name: String,
+        publisher: AnyPublisher<T, Never>,
+        serialize: @escaping (T) -> String
+    ) {
+        var previousValue: String?
+
+        publisher
+            .map(serialize)
+            .removeDuplicates()
+            .sink { [weak self] value in
+                defer { previousValue = value }
+                guard let self, let previousValue else {
+                    return
+                }
+
+                self.track(.settingChanged(
+                    name: name,
+                    oldValue: previousValue,
+                    newValue: value
+                ))
+            }
+            .store(in: &cancellables)
+    }
+
+    private func beginSessionIfNeeded(source: String) {
+        let now = Date()
+        let shouldStartNewSession: Bool
+
+        if let currentSessionId {
+            let elapsed = lastBackgroundAt.map { now.timeIntervalSince($0) } ?? 0
+            shouldStartNewSession = elapsed >= sessionTimeout || currentSessionId.isEmpty
+        } else {
+            shouldStartNewSession = true
+        }
+
+        guard shouldStartNewSession else {
+            return
+        }
+
+        currentSessionId = UUID().uuidString
+        lastBackgroundAt = nil
+        let sessionId = currentSessionId
+
+        Task {
+            await recorder.setSessionId(sessionId)
+            await recorder.record(.sessionStarted(
+                source: source,
+                isFirstLaunch: preferences.hasCompletedFirstLaunch == false
+            ))
+
+            if preferences.hasCompletedFirstLaunch == false {
+                await recorder.record(.appFirstOpened)
+            }
+        }
+    }
+
+    private func track(_ event: AppAnalyticsEvent) {
+        Task {
+            await recorder.record(event)
+        }
+    }
+
+}
+
+private extension NotificationsHandler.NotificationsPermissionState {
+
+    var analyticsValue: String {
+        switch self {
+        case .notDetermined:
+            return "not_determined"
+        case .denied:
+            return "denied"
+        case .noSound:
+            return "granted_no_sound"
+        case .granted:
+            return "granted"
+        }
+    }
+
+}

--- a/Azkar/Sources/Services/AppUsageTracker.swift
+++ b/Azkar/Sources/Services/AppUsageTracker.swift
@@ -37,7 +37,7 @@ final class AppUsageTracker {
         observeNotificationPermissions()
         observeSettingChanges()
 
-        beginSessionIfNeeded(source: "app_launch")
+        beginSessionIfNeeded(source: .appLaunch)
         Task {
             await recorder.cleanup(retainingEventsFor: retentionInterval)
         }
@@ -46,7 +46,7 @@ final class AppUsageTracker {
     private func observeLifecycle() {
         NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
-                self?.beginSessionIfNeeded(source: "foreground")
+                self?.beginSessionIfNeeded(source: .foreground)
             }
             .store(in: &cancellables)
 
@@ -77,64 +77,64 @@ final class AppUsageTracker {
 
     private func observeSettingChanges() {
         observeSetting(
-            name: "content_language",
+            .contentLanguage,
             publisher: preferences.$contentLanguage.eraseToAnyPublisher(),
             serialize: { $0.rawValue }
         )
         observeSetting(
-            name: "zikr_collection_source",
+            .zikrCollectionSource,
             publisher: preferences.$zikrCollectionSource.eraseToAnyPublisher(),
             serialize: { $0.rawValue }
         )
         observeSetting(
-            name: "color_theme",
+            .colorTheme,
             publisher: preferences.$colorTheme.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
         observeSetting(
-            name: "app_theme",
+            .appTheme,
             publisher: preferences.$appTheme.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
         observeSetting(
-            name: "zikr_reading_mode",
+            .zikrReadingMode,
             publisher: preferences.$zikrReadingMode.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
         observeSetting(
-            name: "counter_type",
+            .counterType,
             publisher: preferences.$counterType.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
         observeSetting(
-            name: "counter_position",
+            .counterPosition,
             publisher: preferences.$counterPosition.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
         observeSetting(
-            name: "enable_adhkar_reminder",
+            .enableAdhkarReminder,
             publisher: preferences.$enableAdhkarReminder.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
         observeSetting(
-            name: "enable_jumua_reminder",
+            .enableJumuaReminder,
             publisher: preferences.$enableJumuaReminder.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
         observeSetting(
-            name: "transliteration_type",
+            .transliterationType,
             publisher: preferences.$transliterationType.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
         observeSetting(
-            name: "app_icon",
+            .appIcon,
             publisher: preferences.$appIcon.eraseToAnyPublisher(),
             serialize: String.init(describing:)
         )
     }
 
     private func observeSetting<T: Equatable>(
-        name: String,
+        _ setting: AppAnalyticsSetting,
         publisher: AnyPublisher<T, Never>,
         serialize: @escaping (T) -> String
     ) {
@@ -150,7 +150,7 @@ final class AppUsageTracker {
                 }
 
                 self.track(.settingChanged(
-                    name: name,
+                    setting: setting,
                     oldValue: previousValue,
                     newValue: value
                 ))
@@ -158,7 +158,7 @@ final class AppUsageTracker {
             .store(in: &cancellables)
     }
 
-    private func beginSessionIfNeeded(source: String) {
+    private func beginSessionIfNeeded(source: AppAnalyticsSource) {
         let now = Date()
         let shouldStartNewSession: Bool
 
@@ -200,16 +200,16 @@ final class AppUsageTracker {
 
 private extension NotificationsHandler.NotificationsPermissionState {
 
-    var analyticsValue: String {
+    var analyticsValue: AppAnalyticsNotificationPermissionState {
         switch self {
         case .notDetermined:
-            return "not_determined"
+            return .notDetermined
         case .denied:
-            return "denied"
+            return .denied
         case .noSound:
-            return "granted_no_sound"
+            return .grantedNoSound
         case .granted:
-            return "granted"
+            return .granted
         }
     }
 

--- a/Azkar/Sources/Services/LocalAnalyticsRecorder.swift
+++ b/Azkar/Sources/Services/LocalAnalyticsRecorder.swift
@@ -1,0 +1,125 @@
+import Foundation
+import AzkarServices
+
+actor LocalAnalyticsRecorder {
+
+    private let store: LocalAnalyticsStore
+    private let commonMetadata: () -> [String: Any]
+    private var sessionId: String?
+
+    init(
+        store: LocalAnalyticsStore,
+        commonMetadata: @escaping () -> [String: Any] = { [:] }
+    ) {
+        self.store = store
+        self.commonMetadata = commonMetadata
+    }
+
+    func setSessionId(_ sessionId: String?) {
+        self.sessionId = sessionId
+    }
+
+    func recordEvent(
+        name: String,
+        metadata: [String: Any]? = nil,
+        kind: LocalAnalyticsEventKind = .event
+    ) async {
+        do {
+            try await store.recordEvent(
+                name: name,
+                kind: kind,
+                metadata: sanitizeMetadata(mergedMetadata(metadata)),
+                sessionId: sessionId,
+                recordedAt: Date()
+            )
+        } catch {
+            print("Failed to record local analytics event: \(error.localizedDescription)")
+        }
+    }
+
+    func record(_ event: AppAnalyticsEvent) async {
+        await recordEvent(
+            name: event.name,
+            metadata: event.metadata,
+            kind: .event
+        )
+    }
+
+    func recordScreen(screenName: String, className: String?) async {
+        var metadata: [String: Any] = [:]
+        metadata["class_name"] = className
+        await recordEvent(name: screenName, metadata: metadata, kind: .screen)
+    }
+
+    func recordUserAttribute(_ type: UserAttributeType, value: String) async {
+        await recordEvent(
+            name: type.rawValue,
+            metadata: ["value": value],
+            kind: .userAttribute
+        )
+    }
+
+    func cleanup(retainingEventsFor interval: TimeInterval) async {
+        do {
+            try await store.cleanupEvents(olderThan: interval)
+        } catch {
+            print("Failed to clean up local analytics events: \(error.localizedDescription)")
+        }
+    }
+
+    private func sanitizeMetadata(_ metadata: [String: Any]?) -> [String: String] {
+        guard let metadata else {
+            return [:]
+        }
+
+        return metadata
+            .sorted(by: { $0.key < $1.key })
+            .prefix(24)
+            .reduce(into: [String: String]()) { result, item in
+                guard let value = sanitizeValue(item.value) else {
+                    return
+                }
+                result[item.key] = value
+            }
+    }
+
+    private func mergedMetadata(_ metadata: [String: Any]?) -> [String: Any] {
+        var merged = commonMetadata()
+        metadata?.forEach { key, value in
+            merged[key] = value
+        }
+        return merged
+    }
+
+    private func sanitizeValue(_ value: Any) -> String? {
+        switch value {
+        case let value as String:
+            return truncate(value)
+        case let value as Bool:
+            return value ? "true" : "false"
+        case let value as Int:
+            return String(value)
+        case let value as Int64:
+            return String(value)
+        case let value as Double:
+            return String(value)
+        case let value as Float:
+            return String(value)
+        case let value as URL:
+            return truncate(value.absoluteString)
+        case let value as Date:
+            return ISO8601DateFormatter().string(from: value)
+        default:
+            let description = String(describing: value)
+            guard description.isEmpty == false, description != "nil" else {
+                return nil
+            }
+            return truncate(description)
+        }
+    }
+
+    private func truncate(_ value: String) -> String {
+        String(value.prefix(120))
+    }
+
+}

--- a/Azkar/Sources/Services/LocalAnalyticsRecorder.swift
+++ b/Azkar/Sources/Services/LocalAnalyticsRecorder.swift
@@ -47,7 +47,9 @@ actor LocalAnalyticsRecorder {
 
     func recordScreen(screenName: String, className: String?) async {
         var metadata: [String: Any] = [:]
-        metadata["class_name"] = className
+        if let className {
+            metadata["class_name"] = className
+        }
         await recordEvent(name: screenName, metadata: metadata, kind: .screen)
     }
 

--- a/Azkar/Sources/Services/LocalAnalyticsTarget.swift
+++ b/Azkar/Sources/Services/LocalAnalyticsTarget.swift
@@ -1,0 +1,31 @@
+import AzkarServices
+
+final class LocalAnalyticsTarget: AnalyticsTarget {
+
+    let deliveryPolicy: AnalyticsTargetDeliveryPolicy = .always
+
+    private let recorder: LocalAnalyticsRecorder
+
+    init(recorder: LocalAnalyticsRecorder) {
+        self.recorder = recorder
+    }
+
+    func reportEvent(name: String, metadata: [String: Any]?) {
+        Task {
+            await recorder.recordEvent(name: name, metadata: metadata)
+        }
+    }
+
+    func reportScreen(screenName: String, className: String?) {
+        Task {
+            await recorder.recordScreen(screenName: screenName, className: className)
+        }
+    }
+
+    func setUserAttribute(_ type: UserAttributeType, value: String) {
+        Task {
+            await recorder.recordUserAttribute(type, value: value)
+        }
+    }
+
+}

--- a/Packages/Core/Sources/AzkarServices/Analytics/AnalyticsReporter.swift
+++ b/Packages/Core/Sources/AzkarServices/Analytics/AnalyticsReporter.swift
@@ -6,9 +6,21 @@ import Extensions
 
 /// Protocol that defines the required methods for any analytics reporting target.
 public protocol AnalyticsTarget {
+    var deliveryPolicy: AnalyticsTargetDeliveryPolicy { get }
     func reportEvent(name: String, metadata: [String: Any]?)
     func reportScreen(screenName: String, className: String?)
     func setUserAttribute(_ type: UserAttributeType, value: String)
+}
+
+public enum AnalyticsTargetDeliveryPolicy {
+    case always
+    case whenAnalyticsEnabled
+}
+
+public extension AnalyticsTarget {
+    var deliveryPolicy: AnalyticsTargetDeliveryPolicy {
+        .whenAnalyticsEnabled
+    }
 }
 
 // MARK: - UserAttributeType Enum
@@ -79,11 +91,20 @@ public final class AnalyticsReporter {
     ///   - metadata: Optional dictionary containing additional information about the event.
     public static func reportEvent(_ name: String, metadata: [String: Any]? = nil) {
         shared.serialQueue.sync {
-            if UIApplication.shared.shouldSendAnalytics {
-                for target in shared.targets {
-                    target.reportEvent(name: name, metadata: metadata)
-                }
-            } else {
+            let deliverableTargets = shared.targets.filter {
+                $0.deliveryPolicy == .always || UIApplication.shared.shouldSendAnalytics
+            }
+
+            if deliverableTargets.isEmpty {
+                shared.logEvent(name: name, metadata: metadata)
+                return
+            }
+
+            for target in deliverableTargets {
+                target.reportEvent(name: name, metadata: metadata)
+            }
+
+            if UIApplication.shared.shouldSendAnalytics == false {
                 shared.logEvent(name: name, metadata: metadata)
             }
         }
@@ -95,11 +116,20 @@ public final class AnalyticsReporter {
     ///   - className: The name of the class.
     public static func reportScreen(_ screenName: String, className: String? = nil) {
         shared.serialQueue.sync {
-            if UIApplication.shared.shouldSendAnalytics {
-                for target in shared.targets {
-                    target.reportScreen(screenName: screenName, className: className)
-                }
-            } else {
+            let deliverableTargets = shared.targets.filter {
+                $0.deliveryPolicy == .always || UIApplication.shared.shouldSendAnalytics
+            }
+
+            if deliverableTargets.isEmpty {
+                shared.logScreen(screenName: screenName, className: className)
+                return
+            }
+
+            for target in deliverableTargets {
+                target.reportScreen(screenName: screenName, className: className)
+            }
+
+            if UIApplication.shared.shouldSendAnalytics == false {
                 shared.logScreen(screenName: screenName, className: className)
             }
         }
@@ -111,11 +141,20 @@ public final class AnalyticsReporter {
     ///   - value: The value of the user attribute.
     public static func setUserAttribute(_ type: UserAttributeType, value: String) {
         shared.serialQueue.sync {
-            if UIApplication.shared.shouldSendAnalytics {
-                for target in shared.targets {
-                    target.setUserAttribute(type, value: value)
-                }
-            } else {
+            let deliverableTargets = shared.targets.filter {
+                $0.deliveryPolicy == .always || UIApplication.shared.shouldSendAnalytics
+            }
+
+            if deliverableTargets.isEmpty {
+                shared.logUserAttribute(type, value: value)
+                return
+            }
+
+            for target in deliverableTargets {
+                target.setUserAttribute(type, value: value)
+            }
+
+            if UIApplication.shared.shouldSendAnalytics == false {
                 shared.logUserAttribute(type, value: value)
             }
         }

--- a/Packages/Core/Sources/AzkarServices/Analytics/LocalAnalyticsStore.swift
+++ b/Packages/Core/Sources/AzkarServices/Analytics/LocalAnalyticsStore.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public enum LocalAnalyticsEventKind: String, Codable, Sendable {
+    case event
+    case screen
+    case userAttribute
+}
+
+public struct LocalAnalyticsSummary: Sendable, Equatable {
+    public let totalEvents: Int
+    public let totalSessions: Int
+    public let uniqueEventNames: Int
+    public let uniqueScreens: Int
+    public let lastRecordedAt: Date?
+
+    public init(
+        totalEvents: Int,
+        totalSessions: Int,
+        uniqueEventNames: Int,
+        uniqueScreens: Int,
+        lastRecordedAt: Date?
+    ) {
+        self.totalEvents = totalEvents
+        self.totalSessions = totalSessions
+        self.uniqueEventNames = uniqueEventNames
+        self.uniqueScreens = uniqueScreens
+        self.lastRecordedAt = lastRecordedAt
+    }
+}
+
+public struct LocalAnalyticsEventCount: Sendable, Equatable {
+    public let name: String
+    public let count: Int
+
+    public init(name: String, count: Int) {
+        self.name = name
+        self.count = count
+    }
+}
+
+public protocol LocalAnalyticsStore {
+
+    func recordEvent(
+        name: String,
+        kind: LocalAnalyticsEventKind,
+        metadata: [String: String],
+        sessionId: String?,
+        recordedAt: Date
+    ) async throws
+
+    func fetchSummary(since date: Date?) async throws -> LocalAnalyticsSummary
+
+    func fetchTopEvents(
+        kind: LocalAnalyticsEventKind?,
+        limit: Int,
+        since date: Date?
+    ) async throws -> [LocalAnalyticsEventCount]
+
+    func cleanupEvents(olderThan interval: TimeInterval) async throws
+
+}

--- a/Packages/Interactors/Sources/DatabaseInteractors/AnalyticsSQLiteDatabaseService.swift
+++ b/Packages/Interactors/Sources/DatabaseInteractors/AnalyticsSQLiteDatabaseService.swift
@@ -3,6 +3,51 @@ import Entities
 import GRDB
 import AzkarServices
 
+public final class AnalyticsSQLiteDatabase {
+
+    let writer: DatabaseWriter
+
+    public init(databasePath: String) throws {
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("Create processed_analytics_events table") { db in
+            try ProcessedAnalyticsEvent.createTable(in: db)
+        }
+        migrator.registerMigration("Add index on first_seen_at") { db in
+            try db.create(
+                index: "idx_first_seen_at",
+                on: ProcessedAnalyticsEvent.databaseTableName,
+                columns: ["first_seen_at"]
+            )
+        }
+        migrator.registerMigration("Create local_analytics_events table") { db in
+            try StoredLocalAnalyticsEvent.createTable(in: db)
+        }
+        migrator.registerMigration("Add local analytics indexes") { db in
+            try db.create(
+                index: "idx_local_analytics_recorded_at",
+                on: StoredLocalAnalyticsEvent.databaseTableName,
+                columns: ["recorded_at"]
+            )
+            try db.create(
+                index: "idx_local_analytics_kind_name",
+                on: StoredLocalAnalyticsEvent.databaseTableName,
+                columns: ["kind", "name"]
+            )
+            try db.create(
+                index: "idx_local_analytics_session_id",
+                on: StoredLocalAnalyticsEvent.databaseTableName,
+                columns: ["session_id"]
+            )
+        }
+
+        let configuration = GRDB.Configuration()
+        let writer = try DatabasePool(path: databasePath, configuration: configuration)
+        try migrator.migrate(writer)
+        self.writer = writer
+    }
+
+}
+
 struct ProcessedAnalyticsEvent: Codable, FetchableRecord, PersistableRecord {
     static let databaseTableName = "processed_analytics_events"
 
@@ -29,23 +74,47 @@ struct ProcessedAnalyticsEvent: Codable, FetchableRecord, PersistableRecord {
     }
 }
 
+struct StoredLocalAnalyticsEvent: Codable, FetchableRecord, PersistableRecord {
+    static let databaseTableName = "local_analytics_events"
+
+    var id: Int64?
+    let kind: String
+    let name: String
+    let metadata: String?
+    let sessionId: String?
+    let recordedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case kind
+        case name
+        case metadata
+        case sessionId = "session_id"
+        case recordedAt = "recorded_at"
+    }
+
+    static func createTable(in db: Database) throws {
+        try db.create(table: databaseTableName) { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("kind", .text).notNull()
+            t.column("name", .text).notNull()
+            t.column("metadata", .text)
+            t.column("session_id", .text)
+            t.column("recorded_at", .datetime).notNull()
+        }
+    }
+}
+
 public final class AnalyticsSQLiteDatabaseService: AnalyticsDatabaseService {
 
-    private let database: DatabaseWriter
+    private let writer: DatabaseWriter
 
-    public init(databasePath: String) throws {
-        var migrator = DatabaseMigrator()
-        migrator.registerMigration("Create processed_analytics_events table") { db in
-            try ProcessedAnalyticsEvent.createTable(in: db)
-        }
+    public convenience init(databasePath: String) throws {
+        try self.init(database: AnalyticsSQLiteDatabase(databasePath: databasePath))
+    }
 
-        migrator.registerMigration("Add index on first_seen_at") { db in
-            try db.create(index: "idx_first_seen_at", on: ProcessedAnalyticsEvent.databaseTableName, columns: ["first_seen_at"])
-        }
-
-        let config = GRDB.Configuration()
-        database = try DatabasePool(path: databasePath, configuration: config)
-        try migrator.migrate(database)
+    public init(database: AnalyticsSQLiteDatabase) {
+        writer = database.writer
     }
 
     public func checkAndMarkEventAsProcessed(
@@ -53,7 +122,7 @@ public final class AnalyticsSQLiteDatabaseService: AnalyticsDatabaseService {
         recordType: AnalyticsRecord.RecordType,
         actionType: AnalyticsRecord.ActionType
     ) async throws -> AnalyticsEvent.OccurrenceKind {
-        try await database.write { db in
+        try await writer.write { db in
             let event = ProcessedAnalyticsEvent(
                 objectId: objectId,
                 recordType: recordType.rawValue,
@@ -63,22 +132,18 @@ public final class AnalyticsSQLiteDatabaseService: AnalyticsDatabaseService {
 
             do {
                 try event.insert(db)
-                // Insert succeeded, this is the first occurrence
                 return .first
             } catch let error as DatabaseError {
-                // Check if it's a primary key constraint violation
                 if error.resultCode == .SQLITE_CONSTRAINT {
-                    // Event already exists, this is a repeat
                     return .repeat
                 }
-                // Some other database error, rethrow it
                 throw error
             }
         }
     }
 
     public func cleanupOldEvents(olderThan interval: TimeInterval) async throws {
-        try await database.write { db in
+        try await writer.write { db in
             let cutoffDate = Date().addingTimeInterval(-interval)
             try ProcessedAnalyticsEvent
                 .filter(Column("first_seen_at") < cutoffDate)

--- a/Packages/Interactors/Sources/DatabaseInteractors/LocalAnalyticsSQLiteStore.swift
+++ b/Packages/Interactors/Sources/DatabaseInteractors/LocalAnalyticsSQLiteStore.swift
@@ -1,0 +1,161 @@
+import Foundation
+import GRDB
+import AzkarServices
+
+public final class LocalAnalyticsSQLiteStore: LocalAnalyticsStore {
+
+    private let writer: DatabaseWriter
+
+    public convenience init(databasePath: String) throws {
+        try self.init(database: AnalyticsSQLiteDatabase(databasePath: databasePath))
+    }
+
+    public init(database: AnalyticsSQLiteDatabase) {
+        writer = database.writer
+    }
+
+    public func recordEvent(
+        name: String,
+        kind: LocalAnalyticsEventKind,
+        metadata: [String: String],
+        sessionId: String?,
+        recordedAt: Date
+    ) async throws {
+        let payload = try metadata.isEmpty
+            ? nil
+            : String(data: JSONEncoder().encode(metadata), encoding: .utf8)
+
+        try await writer.write { db in
+            var record = StoredLocalAnalyticsEvent(
+                id: nil,
+                kind: kind.rawValue,
+                name: name,
+                metadata: payload,
+                sessionId: sessionId,
+                recordedAt: recordedAt
+            )
+            try record.insert(db)
+        }
+    }
+
+    public func fetchSummary(since date: Date?) async throws -> LocalAnalyticsSummary {
+        try await writer.read { db in
+            let totalEvents = try Int.fetchOne(
+                db,
+                sql: """
+                SELECT COUNT(*)
+                FROM \(StoredLocalAnalyticsEvent.databaseTableName)
+                \(date == nil ? "" : "WHERE recorded_at >= ?")
+                """,
+                arguments: date.map(statementArguments(for:)) ?? StatementArguments()
+            ) ?? 0
+
+            let totalSessions = try Int.fetchOne(
+                db,
+                sql: """
+                SELECT COUNT(DISTINCT session_id)
+                FROM \(StoredLocalAnalyticsEvent.databaseTableName)
+                WHERE session_id IS NOT NULL
+                \(date == nil ? "" : "AND recorded_at >= ?")
+                """,
+                arguments: date.map(statementArguments(for:)) ?? StatementArguments()
+            ) ?? 0
+
+            let uniqueEventNames = try Int.fetchOne(
+                db,
+                sql: """
+                SELECT COUNT(DISTINCT name)
+                FROM \(StoredLocalAnalyticsEvent.databaseTableName)
+                WHERE kind = ?
+                \(date == nil ? "" : "AND recorded_at >= ?")
+                """,
+                arguments: summaryArguments(kind: .event, date: date)
+            ) ?? 0
+
+            let uniqueScreens = try Int.fetchOne(
+                db,
+                sql: """
+                SELECT COUNT(DISTINCT name)
+                FROM \(StoredLocalAnalyticsEvent.databaseTableName)
+                WHERE kind = ?
+                \(date == nil ? "" : "AND recorded_at >= ?")
+                """,
+                arguments: summaryArguments(kind: .screen, date: date)
+            ) ?? 0
+
+            let lastRecordedAt = try Date.fetchOne(
+                db,
+                sql: """
+                SELECT MAX(recorded_at)
+                FROM \(StoredLocalAnalyticsEvent.databaseTableName)
+                \(date == nil ? "" : "WHERE recorded_at >= ?")
+                """,
+                arguments: date.map(statementArguments(for:)) ?? StatementArguments()
+            )
+
+            return LocalAnalyticsSummary(
+                totalEvents: totalEvents,
+                totalSessions: totalSessions,
+                uniqueEventNames: uniqueEventNames,
+                uniqueScreens: uniqueScreens,
+                lastRecordedAt: lastRecordedAt
+            )
+        }
+    }
+
+    public func fetchTopEvents(
+        kind: LocalAnalyticsEventKind?,
+        limit: Int,
+        since date: Date?
+    ) async throws -> [LocalAnalyticsEventCount] {
+        let safeLimit = max(1, limit)
+
+        return try await writer.read { db in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                SELECT name, COUNT(*) AS count
+                FROM \(StoredLocalAnalyticsEvent.databaseTableName)
+                WHERE (? IS NULL OR kind = ?)
+                AND (? IS NULL OR recorded_at >= ?)
+                GROUP BY name
+                ORDER BY count DESC, name ASC
+                LIMIT ?
+                """,
+                arguments: StatementArguments([
+                    kind?.rawValue,
+                    kind?.rawValue,
+                    date,
+                    date,
+                    safeLimit
+                ])
+            )
+
+            return rows.map {
+                LocalAnalyticsEventCount(name: $0["name"], count: $0["count"])
+            }
+        }
+    }
+
+    public func cleanupEvents(olderThan interval: TimeInterval) async throws {
+        try await writer.write { db in
+            let cutoffDate = Date().addingTimeInterval(-interval)
+            try StoredLocalAnalyticsEvent
+                .filter(Column("recorded_at") < cutoffDate)
+                .deleteAll(db)
+        }
+    }
+
+}
+
+private func summaryArguments(kind: LocalAnalyticsEventKind, date: Date?) -> StatementArguments {
+    var arguments = StatementArguments([kind.rawValue])
+    if let date {
+        arguments += StatementArguments([date])
+    }
+    return arguments
+}
+
+private func statementArguments(for date: Date) -> StatementArguments {
+    StatementArguments([date])
+}


### PR DESCRIPTION
## Summary

Adds a local analytics foundation for app usage data so future product work can rely on on-device history without waiting for new instrumentation.

## What changed

- Added a local SQLite-backed analytics store for durable event history, summaries, top-event queries, and retention cleanup.
- Added typed `AppAnalyticsEvent` definitions and an injectable `AppAnalyticsTracking` pipeline wired through the FactoryKit container.
- Captures local usage for sessions, app entry points, navigation, search, sharing, settings, notification permission changes, category completion, and existing `AnalyticsReporter` screen/event calls.
- Adds common local-only metadata to every event: app version, build number, OS version, device idiom, content language, interface language, pro status, and days since first open.
- Keeps remote analytics behavior unchanged; the new common metadata is only written to the local analytics DB.

## Validation

- `git diff --check HEAD~1 HEAD` passed.
- `scripts/swiftlint.sh` ran, but reports existing warnings in `MainMenuView` type length and `AppDeepLink` cyclomatic complexity.
- Full Xcode build was not run in this environment because the workspace/dependency setup was unavailable earlier during implementation.