### PR TITLE
Remove unused private property minHeight from ArticleScreen

### DIFF
--- a/Packages/Modules/Sources/ArticleReader/ArticleScreen.swift
+++ b/Packages/Modules/Sources/ArticleReader/ArticleScreen.swift
@@ -29,8 +29,6 @@ public struct ArticleScreen: View {
         self.shareOptions = shareOptions
         self.onShareButtonTap = onShareButtonTap
     }
-    
-    private let minHeight = 175.0
     private var maxHeight: CGFloat {
         if viewModel.coverImage?.imageFormat == .titleBackground {
             return 250


### PR DESCRIPTION
The  was declared but never referenced anywhere in the file or the ArticleReader module. The companion  property _is_ used (passed to ), but  has no consumers.

**Change:** Remove one unused line (2 lines deleted total — the declaration and its leading blank line).

**Risk:** None — no code path references this value.