### PR TITLE
Remove force unwrap of Documents directory URL in InstallationDateChecker

### DIFF
--- a/Packages/Modules/Sources/Library/InstallationDateChecker.swift
+++ b/Packages/Modules/Sources/Library/InstallationDateChecker.swift
@@ -3,7 +3,9 @@ import Foundation
 public class InstallationDateChecker {
     /// Returns the date when the app was installed based on the creation date of the Documents directory.
     public static func getAppInstallationDate() -> Date {
-        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return Date()
+        }
         if let attributes = try? FileManager.default.attributesOfItem(atPath: documentsURL.path),
            let creationDate = attributes[.creationDate] as? Date {
             return creationDate


### PR DESCRIPTION
## Change
Replaced `FileManager.default.urls(for: .documentDirectory, ...).first!` with `guard let` in `InstallationDateChecker.getAppInstallationDate()`.

## Reason
Follows the same pattern as earlier PRs (JAW-105, JAW-110) that removed force unwraps. The Documents directory URL should always exist on iOS, but using `guard let` with a fallback to `Date()` is safer and more defensive.

## Verification
- Single-file change, no behavior change in normal execution
- Fallback `Date()` preserves the same default as the original code