### PR TITLE
Consolidate duplicated font URL constants into FontsType.baseURL

### DIFF
--- a/Azkar/Sources/Scenes/Settings/Fonts/FontsListItemViewModel.swift
+++ b/Azkar/Sources/Scenes/Settings/Fonts/FontsListItemViewModel.swift
@@ -15,7 +15,7 @@ struct AppFontViewModel: Identifiable, Equatable, Hashable {
         lhs.id == rhs.id
     }
     
-    private static let baseURL = URL(string: "https://storage.yandexcloud.net/azkar/fonts/files/")!
+    private static let filesBaseURL = FontsType.baseURL.appendingPathComponent("files")
     
     let id = UUID()
     let font: AppFont
@@ -48,8 +48,8 @@ struct AppFontViewModel: Identifiable, Equatable, Hashable {
         
         let referenceName = font.referenceName
         if referenceName != STANDARD_FONT_REFERENCE_NAME {
-            imageURL = AppFontViewModel.baseURL.appendingPathComponent("\(referenceName)/\(referenceName)\(langIdSuffix).png")
-            zipFileURL = AppFontViewModel.baseURL.appendingPathComponent(referenceName).appendingPathComponent("\(referenceName).zip")
+            imageURL = AppFontViewModel.filesBaseURL.appendingPathComponent("\(referenceName)/\(referenceName)\(langIdSuffix).png")
+            zipFileURL = AppFontViewModel.filesBaseURL.appendingPathComponent(referenceName).appendingPathComponent("\(referenceName).zip")
         } else {
             imageURL = nil
             zipFileURL = nil

--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Fonts.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Fonts.swift
@@ -405,5 +405,5 @@ extension ZikrShareOptionsView {
 
     static var defaultArabicFonts: [ArabicFont] { ArabicFont.standardFonts.compactMap { $0 as? ArabicFont } }
     static var defaultTranslationFonts: [TranslationFont] { TranslationFont.standardFonts }
-    static var fontDownloadBaseURL: URL { URL(string: "https://storage.yandexcloud.net/azkar/fonts/files/")! }
+    static var fontDownloadBaseURL: URL { FontsType.baseURL.appendingPathComponent("files") }
 }

--- a/Packages/Modules/Sources/Library/Fonts/FontsService/FontsServiceType.swift
+++ b/Packages/Modules/Sources/Library/Fonts/FontsService/FontsServiceType.swift
@@ -4,13 +4,15 @@ import Foundation
 
 public enum FontsType {
     case arabic, translation
-    
+
+    public static let baseURL = URL(string: "https://storage.yandexcloud.net/azkar/fonts/")!
+
     public var url: URL {
         switch self {
         case .arabic:
-            return URL(string: "https://storage.yandexcloud.net/azkar/fonts/arabic_fonts.json")!
+            return Self.baseURL.appendingPathComponent("arabic_fonts.json")
         case .translation:
-            return URL(string: "https://storage.yandexcloud.net/azkar/fonts/translation_fonts.json")!
+            return Self.baseURL.appendingPathComponent("translation_fonts.json")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract the shared Yandex Cloud font storage base URL into a single `public static let baseURL` constant on `FontsType`
- Remove 3 duplicated `URL(string:)!` force unwraps from `FontsListItemViewModel` and `ZikrShareOptionsView+Fonts`
- Both files now derive their font download URLs from `FontsType.baseURL.appendingPathComponent("files")`

## Files changed
- `Packages/Modules/Sources/Library/Fonts/FontsService/FontsServiceType.swift` — added `baseURL` static constant, refactored `url` computed property
- `Azkar/Sources/Scenes/Settings/Fonts/FontsListItemViewModel.swift` — replaced private force-unwrapped constant with `FontsType.baseURL`-derived value
- `Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Fonts.swift` — same pattern