### PR TITLE
Add accessibility label to font size buttons in share view

### DIFF
--- a/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Sections.swift
+++ b/Azkar/Sources/Scenes/Zikr Share View/ZikrShareOptionsView+Sections.swift
@@ -295,5 +295,6 @@ extension ZikrShareOptionsView {
         })
         .buttonStyle(.plain)
         .disabled(isDisabled)
+        .accessibilityLabel(Text(increasing ? "+" : "-"))
     }
 }


### PR DESCRIPTION
## Summary
- Adds `.accessibilityLabel` to the font size increase/decrease buttons in the share view, which previously used image-only SF Symbols (`plus`/`minus`) with no VoiceOver support.
- VoiceOver users can now identify and interact with these font size controls.
- The change is a single line — `Text(increasing ? "+" : "-")` — appended to the existing `fontSizeButton` view modifier chain.

## Verification
- Confirmed the change is syntactically correct (SwiftUI `.accessibilityLabel` modifier on a `Button`).
- Verified the build error (`ChangelogKit` missing module) is pre-existing on `dev` and unrelated.
- The diff touches only one file, one line.

## Risk
- Minimal. Adding an accessibility label has no effect on the visual layout or behavior of the button.